### PR TITLE
Fix vscode compatibility issue

### DIFF
--- a/src/integrations/terminal/TerminalManager.ts
+++ b/src/integrations/terminal/TerminalManager.ts
@@ -70,15 +70,6 @@ Interestingly, some environments like Cursor enable these APIs even without the 
 This approach allows us to leverage advanced features when available while ensuring broad compatibility.
 */
 declare module "vscode" {
-	// https://github.com/microsoft/vscode/blob/f0417069c62e20f3667506f4b7e53ca0004b4e3e/src/vscode-dts/vscode.d.ts#L7442
-	interface Terminal {
-		shellIntegration?: {
-			cwd?: vscode.Uri
-			executeCommand?: (command: string) => {
-				read: () => AsyncIterable<string>
-			}
-		}
-	}
 	// https://github.com/microsoft/vscode/blob/f0417069c62e20f3667506f4b7e53ca0004b4e3e/src/vscode-dts/vscode.d.ts#L10794
 	interface Window {
 		onDidStartTerminalShellExecution?: (
@@ -86,6 +77,16 @@ declare module "vscode" {
 			thisArgs?: any,
 			disposables?: vscode.Disposable[]
 		) => vscode.Disposable
+	}
+}
+
+// Extend the Terminal type to include our custom properties
+type ExtendedTerminal = vscode.Terminal & {
+	shellIntegration?: {
+		cwd?: vscode.Uri
+		executeCommand?: (command: string) => {
+			read: () => AsyncIterable<string>
+		}
 	}
 }
 
@@ -139,16 +140,17 @@ export class TerminalManager {
 		})
 
 		// if shell integration is already active, run the command immediately
-		if (terminalInfo.terminal.shellIntegration) {
+		const terminal = terminalInfo.terminal as ExtendedTerminal
+		if (terminal.shellIntegration) {
 			process.waitForShellIntegration = false
-			process.run(terminalInfo.terminal, command)
+			process.run(terminal, command)
 		} else {
 			// docs recommend waiting 3s for shell integration to activate
-			pWaitFor(() => terminalInfo.terminal.shellIntegration !== undefined, { timeout: 4000 }).finally(() => {
+			pWaitFor(() => (terminalInfo.terminal as ExtendedTerminal).shellIntegration !== undefined, { timeout: 4000 }).finally(() => {
 				const existingProcess = this.processes.get(terminalInfo.id)
 				if (existingProcess && existingProcess.waitForShellIntegration) {
 					existingProcess.waitForShellIntegration = false
-					existingProcess.run(terminalInfo.terminal, command)
+					existingProcess.run(terminal, command)
 				}
 			})
 		}
@@ -162,7 +164,8 @@ export class TerminalManager {
 			if (t.busy) {
 				return false
 			}
-			const terminalCwd = t.terminal.shellIntegration?.cwd // one of cline's commands could have changed the cwd of the terminal
+			const terminal = t.terminal as ExtendedTerminal
+			const terminalCwd = terminal.shellIntegration?.cwd // one of cline's commands could have changed the cwd of the terminal
 			if (!terminalCwd) {
 				return false
 			}


### PR DESCRIPTION
Not entirely sure how/when this compatibility issue was introduced.

```
> tsc --noEmit

src/integrations/terminal/TerminalManager.ts:75:3 - error TS2687: All declarations of 'shellIntegration' must have identical modifiers.

75   shellIntegration?: {
     ~~~~~~~~~~~~~~~~

src/integrations/terminal/TerminalManager.ts:75:3 - error TS2717: Subsequent property declarations must have the same type.  Property 'shellIntegration' must be of type 'TerminalShellIntegration | undefined', but here has type '{ cwd?: Uri | undefined; executeCommand?: ((command: string) => { read: () => AsyncIterable<string>; }) | undefined; } | undefined'.

75   shellIntegration?: {
     ~~~~~~~~~~~~~~~~

  node_modules/@types/vscode/index.d.ts:7356:12
    7356   readonly shellIntegration: TerminalShellIntegration | undefined;
                    ~~~~~~~~~~~~~~~~
    'shellIntegration' was also declared here.


Found 2 errors in the same file, starting at: src/integrations/terminal/TerminalManager.ts:75
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes TypeScript errors in `TerminalManager.ts` by introducing `ExtendedTerminal` type for compatibility with VSCode's type system.
> 
>   - **TypeScript Compatibility**:
>     - Fixes TypeScript errors in `TerminalManager.ts` by removing the `shellIntegration` declaration from the `vscode` module augmentation.
>     - Introduces `ExtendedTerminal` type to extend `vscode.Terminal` with `shellIntegration` property.
>   - **Code Adjustments**:
>     - Updates `runCommand()` and `getOrCreateTerminal()` methods to use `ExtendedTerminal` type for `terminal` variable.
>     - Ensures compatibility with VSCode's type system while maintaining custom functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for a5eb1e9a60f9c4b1333df689a50d515543724834. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->