### PR TITLE
Adding a terminate task button to quit and restart

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "roo-cline",
   "displayName": "Roo Cline",
   "description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "icon": "assets/icons/icon.png",
   "galleryBanner": {
     "color": "#617A91",

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -147,7 +147,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 							setEnableButtons(true)
 							setPrimaryButtonText("Resume Task")
 							setSecondaryButtonText("Terminate")
-							setDidClickCancel(false)
+							setDidClickCancel(false) // special case where we reset the cancel button state							
 							break
 						case "resume_completed_task":
 							setTextAreaDisabled(false)
@@ -322,12 +322,15 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			case "command":
 			case "tool":
 			case "browser_action_launch":
+				// responds to the API with a "This operation failed" and lets it try again
 				vscode.postMessage({ type: "askResponse", askResponse: "noButtonClicked" })
 				break
 		}
 		setTextAreaDisabled(true)
 		setClineAsk(undefined)
 		setEnableButtons(false)
+		// setPrimaryButtonText(undefined)
+		// setSecondaryButtonText(undefined)
 		disableAutoScrollRef.current = false
 	}, [clineAsk, startNewTask, isStreaming])
 

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -146,8 +146,8 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 							setClineAsk("resume_task")
 							setEnableButtons(true)
 							setPrimaryButtonText("Resume Task")
-							setSecondaryButtonText(undefined)
-							setDidClickCancel(false) // special case where we reset the cancel button state
+							setSecondaryButtonText("Terminate")
+							setDidClickCancel(false)
 							break
 						case "resume_completed_task":
 							setTextAreaDisabled(false)
@@ -316,20 +316,18 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		switch (clineAsk) {
 			case "api_req_failed":
 			case "mistake_limit_reached":
+			case "resume_task":
 				startNewTask()
 				break
 			case "command":
 			case "tool":
 			case "browser_action_launch":
-				// responds to the API with a "This operation failed" and lets it try again
 				vscode.postMessage({ type: "askResponse", askResponse: "noButtonClicked" })
 				break
 		}
 		setTextAreaDisabled(true)
 		setClineAsk(undefined)
 		setEnableButtons(false)
-		// setPrimaryButtonText(undefined)
-		// setSecondaryButtonText(undefined)
 		disableAutoScrollRef.current = false
 	}, [clineAsk, startNewTask, isStreaming])
 

--- a/webview-ui/src/components/chat/__tests__/ChatView.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ExtensionStateContextType } from '../../../context/ExtensionStateContext'
+import ChatView from '../ChatView'
+import { vscode } from '../../../utils/vscode'
+import * as ExtensionStateContext from '../../../context/ExtensionStateContext'
+
+// Mock vscode
+jest.mock('../../../utils/vscode', () => ({
+    vscode: {
+        postMessage: jest.fn()
+    }
+}))
+
+// Mock all components that use problematic dependencies
+jest.mock('../../common/CodeBlock', () => ({
+    __esModule: true,
+    default: () => <div data-testid="mock-code-block" />
+}))
+
+jest.mock('../../common/MarkdownBlock', () => ({
+    __esModule: true,
+    default: () => <div data-testid="mock-markdown-block" />
+}))
+
+jest.mock('../BrowserSessionRow', () => ({
+    __esModule: true,
+    default: () => <div data-testid="mock-browser-session-row" />
+}))
+
+// Update ChatRow mock to capture props
+let chatRowProps = null
+jest.mock('../ChatRow', () => ({
+    __esModule: true,
+    default: (props: any) => {
+        chatRowProps = props
+        return <div data-testid="mock-chat-row" />
+    }
+}))
+
+
+// Mock Virtuoso component
+jest.mock('react-virtuoso', () => ({
+    Virtuoso: ({ children }: any) => (
+        <div data-testid="mock-virtuoso">{children}</div>
+    )
+}))
+
+// Mock VS Code components
+jest.mock('@vscode/webview-ui-toolkit/react', () => ({
+    VSCodeButton: ({ children, onClick }: any) => (
+        <button onClick={onClick}>{children}</button>
+    ),
+    VSCodeProgressRing: () => <div data-testid="progress-ring" />
+}))
+
+describe('ChatView', () => {
+    const mockShowHistoryView = jest.fn()
+    const mockHideAnnouncement = jest.fn()
+
+    let mockState: ExtensionStateContextType
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        
+        mockState = {
+            clineMessages: [],
+            apiConfiguration: {
+                apiProvider: 'anthropic',
+                apiModelId: 'claude-3-sonnet'
+            },
+            version: '1.0.0',
+            customInstructions: '',
+            alwaysAllowReadOnly: true,
+            alwaysAllowWrite: true,
+            alwaysAllowExecute: true,
+            openRouterModels: {},
+            didHydrateState: true,
+            showWelcome: false,
+            theme: 'dark',
+            filePaths: [],
+            taskHistory: [],
+            shouldShowAnnouncement: false,
+            uriScheme: 'vscode',
+            
+            setAlwaysAllowReadOnly: jest.fn(),
+            setAlwaysAllowWrite: jest.fn(),
+            setCustomInstructions: jest.fn(),
+            setAlwaysAllowExecute: jest.fn(),
+            setApiConfiguration: jest.fn(),
+            setShowAnnouncement: jest.fn()
+        }
+        
+        // Mock the useExtensionState hook
+        jest.spyOn(ExtensionStateContext, 'useExtensionState').mockReturnValue(mockState)
+    })
+
+    const renderChatView = () => {
+        return render(
+            <ChatView 
+                isHidden={false}
+                showAnnouncement={false}
+                hideAnnouncement={mockHideAnnouncement}
+                showHistoryView={mockShowHistoryView}
+            />
+        )
+    }
+
+    describe('Streaming State', () => {
+        it('should show cancel button while streaming', () => {
+            mockState.clineMessages = [
+                { 
+                    type: 'say', 
+                    partial: true,
+                    ts: Date.now(),
+                }
+            ]
+            renderChatView()
+            
+            const buttons = screen.queryAllByRole('button')
+            expect(buttons.length).toBeGreaterThan(0)
+        })
+
+        it('should show terminate button when task is paused', () => {
+            mockState.clineMessages = [
+                { 
+                    type: 'ask',
+                    ask: 'resume_task',
+                    ts: Date.now(),
+                }
+            ]
+            renderChatView()
+            
+            const buttons = screen.queryAllByRole('button')
+            expect(buttons.length).toBeGreaterThan(0)
+        })
+
+        it('should show retry button when API error occurs', () => {
+            mockState.clineMessages = [
+                { 
+                    type: 'say',
+                    say: 'error',
+                    ts: Date.now(),
+                }
+            ]
+            renderChatView()
+            
+            const buttons = screen.queryAllByRole('button')
+            expect(buttons.length).toBeGreaterThan(0)
+        })
+    })
+}) 

--- a/webview-ui/src/components/chat/__tests__/ChatView.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.test.tsx
@@ -107,21 +107,31 @@ describe('ChatView', () => {
     }
 
     describe('Streaming State', () => {
-        it('should show cancel button while streaming', () => {
+        it('should show cancel button while streaming and trigger cancel on click', async () => {
             mockState.clineMessages = [
                 { 
-                    type: 'say', 
+                    type: 'say',
+                    say: 'task',
+                    ts: Date.now(),
+                },
+                { 
+                    type: 'say',
+                    say: 'text',
                     partial: true,
                     ts: Date.now(),
                 }
             ]
             renderChatView()
             
-            const buttons = screen.queryAllByRole('button')
-            expect(buttons.length).toBeGreaterThan(0)
+            const cancelButton = screen.getByText('Cancel')
+            await userEvent.click(cancelButton)
+            
+            expect(vscode.postMessage).toHaveBeenCalledWith({
+                type: 'cancelTask'
+            })
         })
 
-        it('should show terminate button when task is paused', () => {
+        it('should show terminate button when task is paused and trigger terminate on click', async () => {
             mockState.clineMessages = [
                 { 
                     type: 'ask',
@@ -131,22 +141,31 @@ describe('ChatView', () => {
             ]
             renderChatView()
             
-            const buttons = screen.queryAllByRole('button')
-            expect(buttons.length).toBeGreaterThan(0)
+            const terminateButton = screen.getByText('Terminate')
+            await userEvent.click(terminateButton)
+            
+            expect(vscode.postMessage).toHaveBeenCalledWith({
+                type: 'clearTask'
+            })
         })
 
-        it('should show retry button when API error occurs', () => {
+        it('should show retry button when API error occurs and trigger retry on click', async () => {
             mockState.clineMessages = [
                 { 
-                    type: 'say',
-                    say: 'error',
+                    type: 'ask',
+                    ask: 'api_req_failed',
                     ts: Date.now(),
                 }
             ]
             renderChatView()
             
-            const buttons = screen.queryAllByRole('button')
-            expect(buttons.length).toBeGreaterThan(0)
+            const retryButton = screen.getByText('Retry')
+            await userEvent.click(retryButton)
+            
+            expect(vscode.postMessage).toHaveBeenCalledWith({
+                type: 'askResponse',
+                askResponse: 'yesButtonClicked'
+            })
         })
     })
 }) 


### PR DESCRIPTION
## Description
Adding a terminate task button to quit and restart. 

It was bothering me that you can't kill a task once it starts running, and the only way to start over, was to restart the IDE. 
 See screenshots below.

NOTE: It wasn't initially very clear to me why this code change works. Here's a quick explanation: When "Terminate" (secondary button) is clicked, it triggers `handleSecondaryButtonClick`. When `handleSecondaryButtonClick` sees that the `lastMessage.ask` was `resume_task`, it knows that the secondary button was "Terminate", so it triggers `startNewTask`. Not great, but that's how the code works.

## Related Issues
N/A

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Other

## Screenshots/How Has This Been Tested?
![terminate_demo](https://github.com/user-attachments/assets/ca18f7ab-038f-4d9a-94d6-42a2a2d3481f)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a "Terminate" button in `ChatView.tsx` to allow task termination and restart, with tests in `ChatView.test.tsx`.
> 
>   - **Behavior**:
>     - Adds "Terminate" button in `ChatView.tsx` for pausing tasks, triggered by `resume_task` state.
>     - `handleSecondaryButtonClick` now starts a new task when `resume_task` is active.
>   - **Testing**:
>     - Adds `ChatView.test.tsx` to test button visibility for streaming, paused, and error states.
>   - **Misc**:
>     - Updates version in `package.json` from `1.0.3` to `1.0.4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for aecbde845e81905dd2144937ed5abc3bd53d26df. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->