### PR TITLE
Add a setAlwaysAllowBrowser checkbox to settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roo-cline",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roo-cline",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",
         "@anthropic-ai/sdk": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "roo-cline",
   "displayName": "Roo Cline",
   "description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "icon": "assets/icons/icon_Roo.png",
   "galleryBanner": {
     "color": "#617A91",
@@ -111,6 +111,15 @@
           "when": "view == claude-dev.SidebarProvider"
         }
       ]
+    },
+    "configuration": {
+      "properties": {
+        "cline.alwaysAllowBrowser": {
+          "type": "boolean",
+          "default": false,
+          "description": "Always allow browser actions without requiring confirmation"
+        }
+      }
     }
   },
   "scripts": {

--- a/src/core/__tests__/Cline.test.ts
+++ b/src/core/__tests__/Cline.test.ts
@@ -239,12 +239,14 @@ describe('Cline', () => {
                 undefined, // alwaysAllowReadOnly
                 undefined, // alwaysAllowWrite
                 undefined, // alwaysAllowExecute
+                undefined, // alwaysAllowBrowser
                 'test task'
             );
 
             expect(cline.alwaysAllowReadOnly).toBe(false);
             expect(cline.alwaysAllowWrite).toBe(false);
             expect(cline.alwaysAllowExecute).toBe(false);
+            expect(cline.alwaysAllowBrowser).toBe(false);
         });
 
         it('should respect provided settings', () => {
@@ -255,12 +257,14 @@ describe('Cline', () => {
                 true,  // alwaysAllowReadOnly
                 true,  // alwaysAllowWrite
                 true,  // alwaysAllowExecute
+                true,  // alwaysAllowBrowser
                 'test task'
             );
 
             expect(cline.alwaysAllowReadOnly).toBe(true);
             expect(cline.alwaysAllowWrite).toBe(true);
             expect(cline.alwaysAllowExecute).toBe(true);
+            expect(cline.alwaysAllowBrowser).toBe(true);
             expect(cline.customInstructions).toBe('custom instructions');
         });
 
@@ -285,6 +289,7 @@ describe('Cline', () => {
                 false,
                 false,
                 false,
+                false,
                 'test task'
             );
         });
@@ -296,6 +301,7 @@ describe('Cline', () => {
                 undefined,
                 false,
                 true,  // alwaysAllowWrite
+                false,
                 false,
                 'test task'
             );
@@ -311,6 +317,7 @@ describe('Cline', () => {
                 undefined,
                 false,
                 false,  // alwaysAllowWrite
+                false,
                 false,
                 'test task'
             );
@@ -350,6 +357,7 @@ describe('Cline', () => {
                 false,      // alwaysAllowReadOnly
                 false,      // alwaysAllowWrite
                 false,      // alwaysAllowExecute
+                false,      // alwaysAllowBrowser
                 'test task' // task
             )
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -35,6 +35,7 @@ export interface ExtensionState {
 	alwaysAllowReadOnly?: boolean
 	alwaysAllowWrite?: boolean
 	alwaysAllowExecute?: boolean
+	alwaysAllowBrowser?: boolean
 	uriScheme?: string
 	clineMessages: ClineMessage[]
 	taskHistory: HistoryItem[]

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -25,6 +25,7 @@ export interface WebviewMessage {
 		| "openMention"
 		| "cancelTask"
 		| "refreshOpenRouterModels"
+		| "alwaysAllowBrowser"
 	text?: string
 	askResponse?: ClineAskResponse
 	apiConfiguration?: ApiConfiguration

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -23,6 +23,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		setAlwaysAllowWrite,
 		alwaysAllowExecute,
 		setAlwaysAllowExecute,
+		alwaysAllowBrowser,
+		setAlwaysAllowBrowser,
 		openRouterModels,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
@@ -39,6 +41,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			vscode.postMessage({ type: "alwaysAllowReadOnly", bool: alwaysAllowReadOnly })
 			vscode.postMessage({ type: "alwaysAllowWrite", bool: alwaysAllowWrite })
 			vscode.postMessage({ type: "alwaysAllowExecute", bool: alwaysAllowExecute })
+			vscode.postMessage({ type: "alwaysAllowBrowser", bool: alwaysAllowBrowser })
 			onDone()
 		}
 	}
@@ -170,6 +173,22 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 					</p>
 				</div>
 
+				<div style={{ marginBottom: 5 }}>
+					<VSCodeCheckbox
+						checked={alwaysAllowBrowser}
+						onChange={(e: any) => setAlwaysAllowBrowser(e.target.checked)}>
+						<span style={{ fontWeight: "500" }}>Always approve browser actions</span>
+					</VSCodeCheckbox>
+					<p
+						style={{
+							fontSize: "12px",
+							marginTop: "5px",
+							color: "var(--vscode-descriptionForeground)",
+						}}>
+						When enabled, Cline will automatically perform browser actions without requiring
+						you to click the Approve button.
+					</p>
+				</div>
 
 				{IS_DEV && (
 					<>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -22,6 +22,7 @@ export interface ExtensionStateContextType extends ExtensionState {
 	setAlwaysAllowReadOnly: (value: boolean) => void
 	setAlwaysAllowWrite: (value: boolean) => void
 	setAlwaysAllowExecute: (value: boolean) => void
+	setAlwaysAllowBrowser: (value: boolean) => void
 	setShowAnnouncement: (value: boolean) => void
 }
 
@@ -118,6 +119,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setAlwaysAllowReadOnly: (value) => setState((prevState) => ({ ...prevState, alwaysAllowReadOnly: value })),
 		setAlwaysAllowWrite: (value) => setState((prevState) => ({ ...prevState, alwaysAllowWrite: value })),
 		setAlwaysAllowExecute: (value) => setState((prevState) => ({ ...prevState, alwaysAllowExecute: value })),
+		setAlwaysAllowBrowser: (value) => setState((prevState) => ({ ...prevState, alwaysAllowBrowser: value })),
 		setShowAnnouncement: (value) => setState((prevState) => ({ ...prevState, shouldShowAnnouncement: value })),
 	}
 


### PR DESCRIPTION
![Screenshot 2024-11-22 at 1 23 47 PM](https://github.com/user-attachments/assets/4a2ead38-55b0-444a-8ddc-84a366377c67)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `alwaysAllowBrowser` setting to allow browser actions without confirmation, updating core logic, UI, and messaging components.
> 
>   - **Behavior**:
>     - Adds `cline.alwaysAllowBrowser` setting in `package.json` to allow browser actions without confirmation.
>     - Updates `Cline` class in `Cline.ts` to handle `alwaysAllowBrowser` for browser actions.
>     - Modifies `ClineProvider` in `ClineProvider.ts` to initialize and update `alwaysAllowBrowser` state.
>   - **UI**:
>     - Adds checkbox for `alwaysAllowBrowser` in `SettingsView.tsx`.
>     - Updates `ExtensionStateContext.tsx` to manage `alwaysAllowBrowser` state.
>   - **Messaging**:
>     - Updates `WebviewMessage.ts` and `ExtensionMessage.ts` to include `alwaysAllowBrowser` message type.
>   - **Tests**:
>     - Updates `Cline.test.ts` to test `alwaysAllowBrowser` behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 0346fdeecb2e96cd68b8d0136cc35becba3e4cbb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->