### PR TITLE
Simplify auto-approving code and make it work better with browser actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,15 +116,6 @@
           "when": "view == claude-dev.SidebarProvider"
         }
       ]
-    },
-    "configuration": {
-      "properties": {
-        "cline.alwaysAllowBrowser": {
-          "type": "boolean",
-          "default": false,
-          "description": "Always allow browser actions without requiring confirmation"
-        }
-      }
     }
   },
   "scripts": {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -197,20 +197,12 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		const { 
 			apiConfiguration, 
 			customInstructions, 
-			alwaysAllowReadOnly, 
-			alwaysAllowWrite, 
-			alwaysAllowExecute,
-			alwaysAllowBrowser 
 		} = await this.getState()
 		
 		this.cline = new Cline(
 			this, 
 			apiConfiguration, 
 			customInstructions, 
-			alwaysAllowReadOnly, 
-			alwaysAllowWrite, 
-			alwaysAllowExecute,
-			alwaysAllowBrowser,
 			task, 
 			images
 		)
@@ -221,20 +213,12 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		const { 
 			apiConfiguration, 
 			customInstructions, 
-			alwaysAllowReadOnly, 
-			alwaysAllowWrite, 
-			alwaysAllowExecute,
-			alwaysAllowBrowser 
 		} = await this.getState()
 		
 		this.cline = new Cline(
 			this,
 			apiConfiguration,
 			customInstructions,
-			alwaysAllowReadOnly,
-			alwaysAllowWrite,
-			alwaysAllowExecute,
-			alwaysAllowBrowser,
 			undefined,
 			undefined,
 			historyItem,
@@ -440,23 +424,18 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						break
 					case "alwaysAllowReadOnly":
 						await this.updateGlobalState("alwaysAllowReadOnly", message.bool ?? undefined)
-						if (this.cline) {
-							this.cline.alwaysAllowReadOnly = message.bool ?? false
-						}
 						await this.postStateToWebview()
 						break
 					case "alwaysAllowWrite":
 						await this.updateGlobalState("alwaysAllowWrite", message.bool ?? undefined)
-						if (this.cline) {
-							this.cline.alwaysAllowWrite = message.bool ?? false
-						}
 						await this.postStateToWebview()
 						break
 					case "alwaysAllowExecute":
 						await this.updateGlobalState("alwaysAllowExecute", message.bool ?? undefined)
-						if (this.cline) {
-							this.cline.alwaysAllowExecute = message.bool ?? false
-						}
+						await this.postStateToWebview()
+						break
+					case "alwaysAllowBrowser":
+						await this.updateGlobalState("alwaysAllowBrowser", message.bool ?? undefined)
 						await this.postStateToWebview()
 						break
 					case "askResponse":
@@ -530,13 +509,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							// await this.postStateToWebview() // new Cline instance will post state when it's ready. having this here sent an empty messages array to webview leading to virtuoso having to reload the entire list
 						}
 
-						break
-					case "alwaysAllowBrowser":
-						await this.updateGlobalState("alwaysAllowBrowser", message.bool ?? undefined)
-						if (this.cline) {
-							this.cline.alwaysAllowBrowser = message.bool ?? false
-						}
-						await this.postStateToWebview()
 						break
 					// Add more switch case statements here as more webview message commands
 					// are created within the webview context (i.e. inside media/main.js)
@@ -840,12 +812,12 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		const { 
 			apiConfiguration, 
 			lastShownAnnouncementId, 
-			customInstructions, 
-			alwaysAllowReadOnly, 
-			alwaysAllowWrite, 
+			customInstructions,
+			alwaysAllowReadOnly,
+			alwaysAllowWrite,
 			alwaysAllowExecute,
-			alwaysAllowBrowser, 
-			taskHistory 
+			alwaysAllowBrowser,
+			taskHistory,
 		} = await this.getState()
 		
 		return {
@@ -947,8 +919,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			alwaysAllowReadOnly,
 			alwaysAllowWrite,
 			alwaysAllowExecute,
-			taskHistory,
 			alwaysAllowBrowser,
+			taskHistory,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
 			this.getGlobalState("apiModelId") as Promise<string | undefined>,
@@ -979,8 +951,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("alwaysAllowReadOnly") as Promise<boolean | undefined>,
 			this.getGlobalState("alwaysAllowWrite") as Promise<boolean | undefined>,
 			this.getGlobalState("alwaysAllowExecute") as Promise<boolean | undefined>,
-			this.getGlobalState("taskHistory") as Promise<HistoryItem[] | undefined>,
 			this.getGlobalState("alwaysAllowBrowser") as Promise<boolean | undefined>,
+			this.getGlobalState("taskHistory") as Promise<HistoryItem[] | undefined>,
 		])
 
 		let apiProvider: ApiProvider

--- a/webview-ui/src/components/chat/__tests__/ChatView.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.test.tsx
@@ -38,7 +38,6 @@ jest.mock('../ChatRow', () => ({
     }
 }))
 
-
 // Mock Virtuoso component
 jest.mock('react-virtuoso', () => ({
     Virtuoso: ({ children }: any) => (
@@ -74,6 +73,7 @@ describe('ChatView', () => {
             alwaysAllowReadOnly: true,
             alwaysAllowWrite: true,
             alwaysAllowExecute: true,
+            alwaysAllowBrowser: true,
             openRouterModels: {},
             didHydrateState: true,
             showWelcome: false,
@@ -82,13 +82,14 @@ describe('ChatView', () => {
             taskHistory: [],
             shouldShowAnnouncement: false,
             uriScheme: 'vscode',
-            
+
+            setApiConfiguration: jest.fn(),
+            setShowAnnouncement: jest.fn(),
+            setCustomInstructions: jest.fn(),
             setAlwaysAllowReadOnly: jest.fn(),
             setAlwaysAllowWrite: jest.fn(),
-            setCustomInstructions: jest.fn(),
             setAlwaysAllowExecute: jest.fn(),
-            setApiConfiguration: jest.fn(),
-            setShowAnnouncement: jest.fn()
+            setAlwaysAllowBrowser: jest.fn()
         }
         
         // Mock the useExtensionState hook
@@ -105,6 +106,118 @@ describe('ChatView', () => {
             />
         )
     }
+
+    describe('Always Allow Logic', () => {
+        it('should auto-approve read-only tool actions when alwaysAllowReadOnly is true', () => {
+            mockState.clineMessages = [
+                { 
+                    type: 'ask',
+                    ask: 'tool',
+                    text: JSON.stringify({ tool: 'readFile' }),
+                    ts: Date.now(),
+                }
+            ]
+            renderChatView()
+            
+            expect(vscode.postMessage).toHaveBeenCalledWith({
+                type: 'askResponse',
+                askResponse: 'yesButtonClicked'
+            })
+        })
+
+        it('should auto-approve write tool actions when alwaysAllowWrite is true', () => {
+            mockState.clineMessages = [
+                { 
+                    type: 'ask',
+                    ask: 'tool',
+                    text: JSON.stringify({ tool: 'editedExistingFile' }),
+                    ts: Date.now(),
+                }
+            ]
+            renderChatView()
+            
+            expect(vscode.postMessage).toHaveBeenCalledWith({
+                type: 'askResponse',
+                askResponse: 'yesButtonClicked'
+            })
+        })
+
+        it('should auto-approve allowed execute commands when alwaysAllowExecute is true', () => {
+            mockState.clineMessages = [
+                { 
+                    type: 'ask',
+                    ask: 'command',
+                    text: 'npm install',
+                    ts: Date.now(),
+                }
+            ]
+            renderChatView()
+            
+            expect(vscode.postMessage).toHaveBeenCalledWith({
+                type: 'askResponse',
+                askResponse: 'yesButtonClicked'
+            })
+        })
+
+        it('should not auto-approve disallowed execute commands even when alwaysAllowExecute is true', () => {
+            mockState.clineMessages = [
+                { 
+                    type: 'ask',
+                    ask: 'command',
+                    text: 'rm -rf /',
+                    ts: Date.now(),
+                }
+            ]
+            renderChatView()
+            
+            expect(vscode.postMessage).not.toHaveBeenCalled()
+        })
+
+        it('should not auto-approve commands with chaining characters when alwaysAllowExecute is true', () => {
+            mockState.clineMessages = [
+                { 
+                    type: 'ask',
+                    ask: 'command',
+                    text: 'npm install && rm -rf /',
+                    ts: Date.now(),
+                }
+            ]
+            renderChatView()
+            
+            expect(vscode.postMessage).not.toHaveBeenCalled()
+        })
+
+        it('should auto-approve browser actions when alwaysAllowBrowser is true', () => {
+            mockState.clineMessages = [
+                { 
+                    type: 'ask',
+                    ask: 'browser_action_launch',
+                    ts: Date.now(),
+                }
+            ]
+            renderChatView()
+            
+            expect(vscode.postMessage).toHaveBeenCalledWith({
+                type: 'askResponse',
+                askResponse: 'yesButtonClicked'
+            })
+        })
+
+        it('should not auto-approve when corresponding alwaysAllow flag is false', () => {
+            mockState.alwaysAllowReadOnly = false
+            mockState.clineMessages = [
+                { 
+                    type: 'ask',
+                    ask: 'tool',
+                    text: JSON.stringify({ tool: 'readFile' }),
+                    ts: Date.now(),
+                }
+            ]
+            renderChatView()
+            
+            expect(vscode.postMessage).not.toHaveBeenCalled()
+        })
+    })
 
     describe('Streaming State', () => {
         it('should show cancel button while streaming and trigger cancel on click', async () => {
@@ -168,4 +281,4 @@ describe('ChatView', () => {
             })
         })
     })
-}) 
+})


### PR DESCRIPTION
I realized that the await this.ask("browser_action_launch", ...) code is important for correctly setting up the browser UI in the chat view (otherwise you just see the base64 encoded screenshot etc). So, this is a simpler/different approach where we just go ahead with the permissions ask but then have code to immediately approve the ask if the corresponding checkbox for auto-approval is set. Seems to work better for me at least. Thoughts?

Before:
![Screenshot 2024-11-28 at 1 05 21 PM](https://github.com/user-attachments/assets/471b35a9-b442-4e7f-a69b-6ad1e1429820)

After:
![Screenshot 2024-11-28 at 1 04 14 PM](https://github.com/user-attachments/assets/9d4c029a-549a-45da-91cb-ba8a9a96b238)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies auto-approval logic by removing redundant configurations and streamlining approval processes in `Cline.ts` and `ChatView.tsx`.
> 
>   - **Behavior**:
>     - Simplifies auto-approval logic by removing `alwaysAllowBrowser`, `alwaysAllowReadOnly`, `alwaysAllowWrite`, and `alwaysAllowExecute` properties from `Cline` class in `Cline.ts`.
>     - Auto-approval now directly handled in `ChatView.tsx` based on `alwaysAllow` flags.
>     - Removes `isAllowedCommand` function from `Cline.ts`.
>   - **Configuration**:
>     - Removes `cline.alwaysAllowBrowser` configuration from `package.json`.
>   - **Tests**:
>     - Updates tests in `Cline.test.ts` and `ChatView.test.tsx` to reflect removal of `alwaysAllow` properties and new auto-approval logic.
>   - **Misc**:
>     - Removes unused `ALLOWED_AUTO_EXECUTE_COMMANDS` in `Cline.ts` and adds it to `ChatView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for a91f5e2c5b048df804f340a4b277ed38ab1f2580. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->