### PR TITLE
Bump version to 2.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log
 
-## Roo Cline 2.1.2
+## Roo Cline 2.1.3
 
 - Roo Cline now publishes to the VS Code Marketplace!
+- Roo Cline now allows browser actions without approval when `alwaysAllowBrowser` is true
 
 ## [2.1.6]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roo-cline",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roo-cline",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",
         "@anthropic-ai/sdk": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "displayName": "Roo Cline",
   "description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
   "publisher": "RooVeterinaryInc",
-  "version": "2.1.2", 
+  "version": "2.1.3", 
   "files": [
-    "bin/roo-cline-2.1.2.vsix", 
+    "bin/roo-cline-2.1.3.vsix", 
     "assets/icons/icon_Roo.png"
   ],
   "icon": "assets/icons/icon_Roo.png",


### PR DESCRIPTION
Forgot to bump the version
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump version to 2.1.3 with updates in `package.json` and `CHANGELOG.md` for new features.
> 
>   - **Version Bump**:
>     - Update version from `2.1.2` to `2.1.3` in `package.json`.
>     - Update `.vsix` file name in `package.json` to `roo-cline-2.1.3.vsix`.
>   - **Changelog**:
>     - Add entry for version `2.1.3` in `CHANGELOG.md`.
>     - Note new features: publishing to VS Code Marketplace and browser actions without approval when `alwaysAllowBrowser` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 34cc2e0e7f0b4f331da5e6f4d5423fd3e30b67fe. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->