### PR TITLE
Relax vscode version targeting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roo-cline",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roo-cline",
-      "version": "2.1.5",
+      "version": "2.1.6",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",
         "@anthropic-ai/sdk": "^0.26.0",
@@ -57,7 +57,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "vscode": "1.93.1"
+        "vscode": "^1.93.1"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "displayName": "Roo Cline",
   "description": "Autonomous coding agent right in your IDE, capable of creating/editing files, running commands, using the browser, and more with your permission every step of the way.",
   "publisher": "RooVeterinaryInc",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "files": [
-    "bin/roo-cline-2.1.5.vsix",
+    "bin/roo-cline-2.1.6.vsix",
     "assets/icons/icon_Roo.png"
   ],
   "icon": "assets/icons/icon_Roo.png",
@@ -14,7 +14,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "1.93.1"
+    "vscode": "^1.93.1"
   },
   "author": {
     "name": "Roo Vet"


### PR DESCRIPTION
Getting this trying to install in vscode otherwise

<img width="261" alt="Screenshot 2024-11-29 at 9 58 29 PM" src="https://github.com/user-attachments/assets/0ac67931-de04-4884-84b0-2fd7577ae6a4">

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `package.json` to allow newer `vscode` versions and increment package version to `2.1.6`.
> 
>   - **Versioning**:
>     - Update `version` in `package.json` from `2.1.5` to `2.1.6`.
>     - Update VSIX file path in `package.json` to `bin/roo-cline-2.1.6.vsix`.
>   - **Compatibility**:
>     - Change `vscode` engine version in `package.json` from `1.93.1` to `^1.93.1` to allow newer versions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 36b82a8b191dd0ab93c8202ded49829c24859e26. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->