### PR TITLE
feat(extension.ts): use rocket icon

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,8 +76,8 @@ export function activate(context: vscode.ExtensionContext) {
 		// TODO: use better svg icon with light and dark variants (see https://stackoverflow.com/questions/58365687/vscode-extension-iconpath)
 
 		panel.iconPath = {
-			light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "robot_panel_light.png"),
-			dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "robot_panel_dark.png"),
+			light: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "rocket.png"),
+			dark: vscode.Uri.joinPath(context.extensionUri, "assets", "icons", "rocket.png"),
 		}
 		tabProvider.resolveWebviewView(panel)
 


### PR DESCRIPTION
* Use `rocket.png` to visually differentiate from `robot_panel_dark.png` and `robot_panel_light.png`

Use case:
* Install both https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline and https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev in VS code
* Instead of hovering over to visually differentiate between "Roo Cline" and "Cline"
  * This may allow one to visually differentiate without hovering over