### PR TITLE
fix(openrouter.ts): HTTP-Referer and X-Title

### DIFF
--- a/cli/api/providers/openrouter.ts
+++ b/cli/api/providers/openrouter.ts
@@ -32,8 +32,8 @@ export class OpenRouterHandler {
         headers: {
           "Authorization": `Bearer ${this.apiKey}`,
           "Content-Type": "application/json",
-          "HTTP-Referer": "https://github.com/mattvr/roo-cline",
-          "X-Title": "Cline CLI"
+          "HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
+          "X-Title": "Roo Cline"
         },
         body: JSON.stringify({
           model: this.model,


### PR DESCRIPTION
Reference: https://github.com/cline/cline/commit/bf05131b8106037b22a79a271e0db69f1b67fa62
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `HTTP-Referer` and `X-Title` headers in `openrouter.ts` for correct request identification.
> 
>   - **Headers Update**:
>     - In `openrouter.ts`, updated `HTTP-Referer` from `https://github.com/mattvr/roo-cline` to `https://github.com/RooVetGit/Roo-Cline`.
>     - Updated `X-Title` from `Cline CLI` to `Roo Cline`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for d7e0ac3837b4b3a6c26f6392b01760fccb89af30. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->