### PR TITLE
Restoring vsix build target

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
+    "vsix": "vsce package --out bin",
     "compile": "npm run check-types && npm run lint && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",


### PR DESCRIPTION
This was incorrectly removed in a previous PR.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores `vsix` build target in `package.json` and adds `roo-cline-2.1.11.vsix` to `bin/`.
> 
>   - **Scripts**:
>     - Restores `vsix` build target in `package.json` to create VSIX package using `vsce package --out bin`.
>   - **Files**:
>     - Adds `roo-cline-2.1.11.vsix` to `bin/` directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 5c2867573c31dd9e54d9401624e1094580577ea0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->