### PR TITLE
Removing manual vsix steps in favor of marketplace publishing

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -27,6 +27,5 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: |
           current_package_version=$(node -p "require('./package.json').version")
-          npm run vsix
           npm run publish:marketplace
           echo "Successfully published version $current_package_version to VS Code Marketplace"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules
 .DS_Store
 
 .npmrc
+
+roo-cline-*.vsix

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
+    "vsix": "vsce package",
     "compile": "npm run check-types && npm run lint && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run package",
-    "vsix": "vsce package --out bin",
     "compile": "npm run check-types && npm run lint && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",


### PR DESCRIPTION
The vsix build target was added to support manual builds and manual distribution of vsix binaries. 

Now that we're publishing directly to the marketplace, this target and build step should no longer be needed.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove manual VSIX packaging steps in favor of direct marketplace publishing.
> 
>   - **Build Process**:
>     - Removed `vsix` script from `scripts` in `package.json`.
>     - Deleted `roo-cline-2.1.11.vsix` from `bin`.
>     - Removed `npm run vsix` step from `marketplace-publish.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for a707a47d93977554ea35ef3139bcb17220098a9e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->