### PR TITLE
Add summarized changelog to the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Roo-Cline
 
-## Roo Packaging and Installation
-
-### Updating Version (for a new release)
-
-1. Bump the version in `package.json`
-2. Update the version number in the `files` list in `package.json`
-
-After installation, Roo Cline will appear in your VSCode-compatible editor's installed extensions list. You can verify this by opening your editor's Extensions panel (Cmd/Ctrl+Shift+X) and checking under the "Installed" section.
+A fork of Cline, an autonomous coding agent, with some added experimental configuration and automation features.
+- Auto-approval capabilities for commands, write, and browser operations
+- Support for .clinerules per-project custom instructions
+- Ability to run side-by-side with Cline
+- Support for playing sound effects
+- Support for OpenRouter compression
+- Support for editing through diffs
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ A fork of Cline, an autonomous coding agent, with some added experimental config
 - Support for OpenRouter compression
 - Support for editing through diffs
 
+Creating a snake game with "Always approve write operations" and "Always approve browser actions":
+
+https://github.com/user-attachments/assets/c2bb31dc-e9b2-4d73-885d-17f1471a4987
+
+
 ---
 
 # Cline (prev. Claude Dev) – \#1 on OpenRouter


### PR DESCRIPTION
Getting some feedback in Discord that it would be nice to have more info on the VSCode marketplace landing page, which is fair.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a summarized changelog to the top of `README.md` to describe Roo-Cline's features for the VSCode marketplace.
> 
>   - **README.md**:
>     - Adds a summarized changelog at the top, describing Roo-Cline as a fork of Cline with additional features.
>     - Lists features such as auto-approval capabilities, support for .clinerules, side-by-side operation with Cline, sound effects, OpenRouter compression, and editing through diffs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for c7ec832db76939d4eb1ccf5a168c4531f63e7cd9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->