### PR TITLE
Added support for gemini-exp-1206

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -278,6 +278,14 @@ export const geminiModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 	},
+	"gemini-exp-1206": {
+		maxTokens: 8192,
+		contextWindow: 2_097_152,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+	},
 } as const satisfies Record<string, ModelInfo>
 
 // OpenAI Native


### PR DESCRIPTION
Added support for additional new model, gemini-exp-1206.

Modification should have no functional impact aside from adding the possibility of using the new model, which is performing similarly to Claude3.5 and has a generous free allowance, making it a great asset for this improved version of Cline.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added `gemini-exp-1206` model to `geminiModels` in `api.ts` with specific attributes.
> 
>   - **Models**:
>     - Added `gemini-exp-1206` to `geminiModels` in `api.ts` with `maxTokens: 8192`, `contextWindow: 2_097_152`, `supportsImages: true`, `supportsPromptCache: false`, `inputPrice: 0`, `outputPrice: 0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 8d876828ed87e62d6bd5b343530f8463757b2ed0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->