### PR TITLE
Handle Windows line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Roo Cline Changelog
 
+## [2.1.18]
+
+- Diff editing bugfix to handle Windows line endings
+
 ## [2.1.17]
 
 - Switch to search/replace diffs in experimental diff editing mode

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A fork of Cline, an autonomous coding agent, with some added experimental config
 - Unit test coverage (written almost entirely by Roo Cline!)
 - Support for playing sound effects
 - Support for OpenRouter compression
-- Support for editing through diffs (very experimental)
 - Support for gemini-exp-1206
 - Support for copying prompts from the history screen
+- Support for editing through diffs / handling truncated full-file edits
 
 Here's an example of Roo-Cline autonomously creating a snake game with "Always approve write operations" and "Always approve browser actions" turned on:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roo-cline",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roo-cline",
-      "version": "2.1.17",
+      "version": "2.1.18",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",
         "@anthropic-ai/sdk": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Roo Cline",
   "description": "A fork of Cline, an autonomous coding agent, with some added experimental configuration and automation features.",
   "publisher": "RooVeterinaryInc",
-  "version": "2.1.17",
+  "version": "2.1.18",
   "icon": "assets/icons/rocket.png",
   "galleryBanner": {
     "color": "#617A91",

--- a/src/core/diff/strategies/__tests__/search-replace.test.ts
+++ b/src/core/diff/strategies/__tests__/search-replace.test.ts
@@ -181,6 +181,23 @@ function test() {
             expect(result).toBe("\tfunction test() {\n\t\t// First comment\n\t\t// Second comment\n\t\treturn true;\n\t}")
         })
 
+        it('should handle Windows-style CRLF line endings', () => {
+            const originalContent = "function test() {\r\n    return true;\r\n}\r\n"
+            const diffContent = `test.ts
+<<<<<<< SEARCH
+function test() {
+    return true;
+}
+=======
+function test() {
+    return false;
+}
+>>>>>>> REPLACE`
+
+            const result = strategy.applyDiff(originalContent, diffContent)
+            expect(result).toBe("function test() {\r\n    return false;\r\n}\r\n")
+        })
+
         it('should return false if search content does not match', () => {
             const originalContent = `function hello() {
     console.log("hello")

--- a/src/core/diff/strategies/search-replace.ts
+++ b/src/core/diff/strategies/search-replace.ts
@@ -70,10 +70,13 @@ Your search/replace content here
 
         const [_, searchContent, replaceContent] = match;
         
-        // Split content into lines
-        const searchLines = searchContent.trim().split('\n');
-        const replaceLines = replaceContent.trim().split('\n');
-        const originalLines = originalContent.split('\n');
+        // Detect line ending from original content
+        const lineEnding = originalContent.includes('\r\n') ? '\r\n' : '\n';
+        
+        // Split content into lines, handling both \n and \r\n
+        const searchLines = searchContent.trim().split(/\r?\n/);
+        const replaceLines = replaceContent.trim().split(/\r?\n/);
+        const originalLines = originalContent.split(/\r?\n/);
         
         // Find the search content in the original
         let matchIndex = -1;
@@ -166,6 +169,6 @@ Your search/replace content here
         const beforeMatch = originalLines.slice(0, matchIndex);
         const afterMatch = originalLines.slice(matchIndex + searchLines.length);
         
-        return [...beforeMatch, ...indentedReplace, ...afterMatch].join('\n');
+        return [...beforeMatch, ...indentedReplace, ...afterMatch].join(lineEnding);
     }
 }

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -296,7 +296,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 
 					<div style={{ marginBottom: 5 }}>
 						<VSCodeCheckbox checked={diffEnabled} onChange={(e: any) => setDiffEnabled(e.target.checked)}>
-							<span style={{ fontWeight: "500" }}>Enable editing through diffs (very experimental!)</span>
+							<span style={{ fontWeight: "500" }}>Enable editing through diffs</span>
 						</VSCodeCheckbox>
 						<p
 							style={{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes handling of Windows-style CRLF line endings in diff editing functionality, with updated tests and documentation.
> 
>   - **Behavior**:
>     - `applyDiff()` in `search-replace.ts` now handles Windows-style CRLF line endings by detecting line endings and preserving them in the output.
>     - Added test case in `search-replace.test.ts` to verify handling of CRLF line endings.
>   - **Documentation**:
>     - Updated `CHANGELOG.md` to include the bugfix for Windows line endings.
>     - Updated `README.md` to clarify support for editing through diffs and handling truncated full-file edits.
>   - **Misc**:
>     - Version bump in `package.json` from 2.1.17 to 2.1.18.
>     - Removed "very experimental" label from diff editing feature in `SettingsView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 9f9162cd2d4fa7032f29c93006331690a757f2ce. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->