### PR TITLE
Fix code scanning alert no. 2: Prototype-polluting function

### DIFF
--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -462,10 +462,13 @@ export const highlight = (
 		let i: number
 
 		for (i = 0; i < pathValue.length - 1; i++) {
+			if (pathValue[i] === "__proto__" || pathValue[i] === "constructor") return
 			obj = obj[pathValue[i]] as Record<string, any>
 		}
 
-		obj[pathValue[i]] = value
+		if (pathValue[i] !== "__proto__" && pathValue[i] !== "constructor") {
+			obj[pathValue[i]] = value
+		}
 	}
 
 	// Function to merge overlapping regions


### PR DESCRIPTION
Fixes [https://github.com/RooVetGit/Roo-Cline/security/code-scanning/2](https://github.com/RooVetGit/Roo-Cline/security/code-scanning/2) and https://github.com/RooVetGit/Roo-Cline/issues/65

To fix the prototype pollution issue, we need to ensure that the `set` function does not allow assignment to special properties like `__proto__` and `constructor`. This can be achieved by adding a check to skip these properties during the assignment process.

- Modify the `set` function to include a check that skips the assignment if the property name is `__proto__` or `constructor`.
- This change will be made in the `webview-ui/src/components/history/HistoryView.tsx` file, specifically within the `set` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix prototype pollution vulnerability in `HistoryView.tsx` by preventing assignment to `__proto__` and `constructor`.
> 
>   - **Security Fix**:
>     - Modify `set` function in `HistoryView.tsx` to prevent assignment to `__proto__` and `constructor` properties, addressing prototype pollution vulnerability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for b2f0aaec8a85d9ed7ef3274194371163b9e5b778. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->