### PR TITLE
Stop appending newlines to files when applying diffs

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -124,17 +124,18 @@ export class DiffViewProvider {
 				edit.delete(document.uri, new vscode.Range(this.streamedLines.length, 0, document.lineCount, 0))
 				await vscode.workspace.applyEdit(edit)
 			}
-			// Add empty last line if original content had one
+			// Preserve empty last line if original content had one
 			const hasEmptyLastLine = this.originalContent?.endsWith("\n")
-			if (hasEmptyLastLine) {
-				const accumulatedLines = accumulatedContent.split("\n")
-				if (accumulatedLines[accumulatedLines.length - 1] !== "") {
-					accumulatedContent += "\n"
-				}
+			if (hasEmptyLastLine && !accumulatedContent.endsWith("\n")) {
+				accumulatedContent += "\n"
 			}
-			// Clear all decorations at the end (before applying final edit)
-			this.fadedOverlayController.clear()
-			this.activeLineController.clear()
+			// Apply the final content
+			const finalEdit = new vscode.WorkspaceEdit()
+			finalEdit.replace(document.uri, new vscode.Range(0, 0, document.lineCount, 0), accumulatedContent)
+						await vscode.workspace.applyEdit(finalEdit)
+						// Clear all decorations at the end (after applying final edit)
+						this.fadedOverlayController.clear()
+						this.activeLineController.clear()
 		}
 	}
 

--- a/src/integrations/editor/__tests__/DiffViewProvider.test.ts
+++ b/src/integrations/editor/__tests__/DiffViewProvider.test.ts
@@ -1,0 +1,100 @@
+import { DiffViewProvider } from '../DiffViewProvider';
+import * as vscode from 'vscode';
+
+// Mock vscode
+jest.mock('vscode', () => ({
+	workspace: {
+		applyEdit: jest.fn(),
+	},
+	window: {
+		createTextEditorDecorationType: jest.fn(),
+	},
+	WorkspaceEdit: jest.fn().mockImplementation(() => ({
+		replace: jest.fn(),
+		delete: jest.fn(),
+	})),
+	Range: jest.fn(),
+	Position: jest.fn(),
+	Selection: jest.fn(),
+	TextEditorRevealType: {
+		InCenter: 2,
+	},
+}));
+
+// Mock DecorationController
+jest.mock('../DecorationController', () => ({
+	DecorationController: jest.fn().mockImplementation(() => ({
+		setActiveLine: jest.fn(),
+		updateOverlayAfterLine: jest.fn(),
+		clear: jest.fn(),
+	})),
+}));
+
+describe('DiffViewProvider', () => {
+	let diffViewProvider: DiffViewProvider;
+	const mockCwd = '/mock/cwd';
+	let mockWorkspaceEdit: { replace: jest.Mock; delete: jest.Mock };
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockWorkspaceEdit = {
+			replace: jest.fn(),
+			delete: jest.fn(),
+		};
+		(vscode.WorkspaceEdit as jest.Mock).mockImplementation(() => mockWorkspaceEdit);
+
+		diffViewProvider = new DiffViewProvider(mockCwd);
+		// Mock the necessary properties and methods
+		(diffViewProvider as any).relPath = 'test.txt';
+		(diffViewProvider as any).activeDiffEditor = {
+			document: {
+				uri: { fsPath: `${mockCwd}/test.txt` },
+				getText: jest.fn(),
+				lineCount: 10,
+			},
+			selection: {
+				active: { line: 0, character: 0 },
+				anchor: { line: 0, character: 0 },
+			},
+			edit: jest.fn().mockResolvedValue(true),
+			revealRange: jest.fn(),
+		};
+		(diffViewProvider as any).activeLineController = { setActiveLine: jest.fn(), clear: jest.fn() };
+		(diffViewProvider as any).fadedOverlayController = { updateOverlayAfterLine: jest.fn(), clear: jest.fn() };
+	});
+
+	describe('update method', () => {
+		it('should preserve empty last line when original content has one', async () => {
+			(diffViewProvider as any).originalContent = 'Original content\n';
+			await diffViewProvider.update('New content', true);
+
+			expect(mockWorkspaceEdit.replace).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.anything(),
+				'New content\n'
+			);
+		});
+
+		it('should not add extra newline when accumulated content already ends with one', async () => {
+			(diffViewProvider as any).originalContent = 'Original content\n';
+			await diffViewProvider.update('New content\n', true);
+
+			expect(mockWorkspaceEdit.replace).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.anything(),
+				'New content\n'
+			);
+		});
+
+		it('should not add newline when original content does not end with one', async () => {
+			(diffViewProvider as any).originalContent = 'Original content';
+			await diffViewProvider.update('New content', true);
+
+			expect(mockWorkspaceEdit.replace).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.anything(),
+				'New content'
+			);
+		});
+	});
+});


### PR DESCRIPTION
I've been running into an issue where the diff editing was adding an extra newline at the bottom of the file every time it ran. This seems to fix it 🙏 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent unnecessary newline addition at file end in `DiffViewProvider` and add tests for newline handling.
> 
>   - **Behavior**:
>     - Modify `update` method in `DiffViewProvider` to prevent adding extra newline at the end of files unless the original content had one.
>     - Ensure final content application respects original newline presence.
>   - **Tests**:
>     - Add tests in `DiffViewProvider.test.ts` to verify newline handling behavior in `update` method.
>     - Test cases include preserving newline, not adding extra newline, and not adding newline when original content lacks it.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 413f10650f4c5ee74ed522156bf3008c5fabc22c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->