### PR TITLE
Larger text area with support for dragging in images

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -689,7 +689,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	useEvent("wheel", handleWheel, window, { passive: true }) // passive improves scrolling performance
 
 	const placeholderText = useMemo(() => {
-		const text = task ? "Type a message (@ to add context)..." : "Type your task here (@ to add context)..."
+		const text = task ? "Type a message...\n(@ to add context, hold shift to drag in images)" : "Type your task here...\n(@ to add context, hold shift to drag in images)"
 		return text
 	}, [task])
 


### PR DESCRIPTION
If anyone has any ideas for why you need to hold shift to drag images into vscode, I'm all ears!

Before:
![Screenshot 2024-12-11 at 3 53 11 PM](https://github.com/user-attachments/assets/7ab9716e-903d-4902-9ff3-5f2f163c05ce)

After:
![Screenshot 2024-12-11 at 3 52 50 PM](https://github.com/user-attachments/assets/1ae53cee-911b-4b4f-aa9c-f543dfd67398)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `ChatTextArea` to support image dragging and update placeholder text in `ChatView` to guide users on this feature.
> 
>   - **Behavior**:
>     - `ChatTextArea.tsx`: Added `onDrop` and `onDragOver` handlers to support dragging images into the text area. Supports `png`, `jpeg`, `webp` formats.
>     - `ChatView.tsx`: Updated placeholder text to "Type a message...\n(@ to add context, hold shift to drag in images)".
>   - **UI Adjustments**:
>     - `ChatTextArea.tsx`: Adjusted `minRows` to 2 and `maxRows` to 20 for the text area.
>     - Modified styles for better alignment and spacing in `ChatTextArea.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for d7e35d08340fd56db200e2eb95f4c9d7624bfe4c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->