### PR TITLE
Update README.md for Gemini 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A fork of Cline, an autonomous coding agent, with some added experimental config
 - Unit test coverage (written almost entirely by Roo Cline!)
 - Support for playing sound effects
 - Support for OpenRouter compression
-- Support for gemini-exp-1206
 - Support for copying prompts from the history screen
 - Support for editing through diffs / handling truncated full-file edits
+- Support for newer Gemini models (gemini-exp-1206 and gemini-2.0-flash-exp)
 
 Here's an example of Roo-Cline autonomously creating a snake game with "Always approve write operations" and "Always approve browser actions" turned on:
 


### PR DESCRIPTION
Forgot to update the readme with Gemini 2
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `README.md` to include support for `gemini-2.0-flash-exp` model.
> 
>   - **Documentation**:
>     - Update `README.md` to include support for `gemini-2.0-flash-exp` model alongside `gemini-exp-1206`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for f3271659c9efe8d5c537d7c697762bbec8713997. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->