### PR TITLE
Add 'Include stream options' checkbox for OpenAI-compatible providers

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -45,7 +45,7 @@ export class OpenAiHandler implements ApiHandler {
 			stream: true,
 		}
 
-		if (this.options.includeStreamOptions) {
+		if (this.options.includeStreamOptions ?? true) {
 			requestOptions.stream_options = { include_usage: true }
 		}
 

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -32,18 +32,24 @@ export class OpenAiHandler implements ApiHandler {
 		}
 	}
 
+	// Include stream_options for OpenAI Compatible providers if the checkbox is checked
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
 			...convertToOpenAiMessages(messages),
 		]
-		const stream = await this.client.chat.completions.create({
+		const requestOptions: OpenAI.Chat.ChatCompletionCreateParams = {
 			model: this.options.openAiModelId ?? "",
 			messages: openAiMessages,
 			temperature: 0,
 			stream: true,
-			stream_options: { include_usage: true },
-		})
+		}
+
+		if (this.options.includeStreamOptions) {
+			requestOptions.stream_options = { include_usage: true }
+		}
+
+		const stream = await this.client.chat.completions.create(requestOptions)
 		for await (const chunk of stream) {
 			const delta = chunk.choices[0]?.delta
 			if (delta?.content) {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -35,6 +35,7 @@ export interface ApiHandlerOptions {
 	azureApiVersion?: string
 	openRouterUseMiddleOutTransform?: boolean
 	includeStreamOptions?: boolean
+	setAzureApiVersion?: boolean
 }
 
 export type ApiConfiguration = ApiHandlerOptions & {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -34,6 +34,7 @@ export interface ApiHandlerOptions {
 	openAiNativeApiKey?: string
 	azureApiVersion?: string
 	openRouterUseMiddleOutTransform?: boolean
+	includeStreamOptions?: boolean
 }
 
 export type ApiConfiguration = ApiHandlerOptions & {

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -445,6 +445,24 @@ const ApiOptions = ({ showModelOptions, apiErrorMessage, modelIdErrorMessage }: 
 						placeholder={"Enter Model ID..."}>
 						<span style={{ fontWeight: 500 }}>Model ID</span>
 					</VSCodeTextField>
+					<div style={{ display: 'flex', alignItems: 'center' }}>
+						<VSCodeCheckbox
+							checked={apiConfiguration?.includeStreamOptions ?? true}
+							onChange={(e: any) => {
+								const isChecked = e.target.checked
+								setApiConfiguration({
+									...apiConfiguration,
+									includeStreamOptions: isChecked
+								})
+							}}>
+							Include stream options
+						</VSCodeCheckbox>
+						<span
+							className="codicon codicon-info"
+							title="Stream options are for { include_usage: true }. Some providers may not support this option."
+							style={{ marginLeft: '5px', cursor: 'help' }}
+						></span>
+					</div>
 					<VSCodeCheckbox
 						checked={azureApiVersionSelected}
 						onChange={(e: any) => {


### PR DESCRIPTION
This PR addresses the issue reported in #83 by adding a configurable option to include stream options for OpenAI-compatible providers.

Changes made:
1. Added an 'Include stream options' checkbox in the UI for OpenAI Compatible providers.
2. Positioned the new checkbox before the Azure API version settings.
3. Added an informational hover icon explaining the purpose and limitations of the option.
4. Updated the OpenAiHandler to include stream options by default unless explicitly disabled.
5. Fixed a TypeScript error in the AzureOpenAI client options.

Key features:
- The checkbox allows users to toggle the inclusion of 'stream_options: { include_usage: true }' in API requests.
- An informational hover provides context: 'Stream options are for { include_usage: true }. Some providers may not support this option.'
- The option defaults to true (checked) if not previously set.

This implementation improves flexibility for users working with different OpenAI-compatible providers while maintaining ease of use and providing clear documentation within the UI.

![Screenshot 2024-12-12 at 9 23 39 AM](https://github.com/user-attachments/assets/d04a4b51-316a-46ef-8463-e8a4f2b88adc)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 'Include stream options' checkbox for OpenAI-compatible providers, updating `OpenAiHandler` to respect this setting and fixing a TypeScript error.
> 
>   - **UI Changes**:
>     - Add 'Include stream options' checkbox in `ApiOptions.tsx` for OpenAI-compatible providers.
>     - Checkbox defaults to checked (true) and is positioned before Azure API version settings.
>     - Add informational hover icon explaining stream options.
>   - **Backend Changes**:
>     - Update `OpenAiHandler` in `openai.ts` to include `stream_options` by default unless disabled.
>   - **Misc**:
>     - Fix TypeScript error in AzureOpenAI client options in `openai.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 2cfd76c305b480b59e8bc0b1becd6c1397e65e19. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->