### PR TITLE
Support fuzzy matching for apply_diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Roo Cline Changelog
 
+## [2.2.6]
+
+-   Add a fuzzy match tolerance when applying diffs
+
 ## [2.2.5]
 
 -   Allow MCP servers to be enabled/disabled

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roo-cline",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roo-cline",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",
         "@anthropic-ai/sdk": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Roo Cline",
   "description": "A fork of Cline, an autonomous coding agent, with some added experimental configuration and automation features.",
   "publisher": "RooVeterinaryInc",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "icon": "assets/icons/rocket.png",
   "galleryBanner": {
     "color": "#617A91",

--- a/src/core/diff/DiffStrategy.ts
+++ b/src/core/diff/DiffStrategy.ts
@@ -7,9 +7,9 @@ import { SearchReplaceDiffStrategy } from './strategies/search-replace'
  * @returns The appropriate diff strategy for the model
  */
 export function getDiffStrategy(model: string): DiffStrategy {
-    // For now, return SearchReplaceDiffStrategy for all models
+    // For now, return SearchReplaceDiffStrategy for all models (with a fuzzy threshold of 0.9)
     // This architecture allows for future optimizations based on model capabilities
-    return new SearchReplaceDiffStrategy()
+    return new SearchReplaceDiffStrategy(0.9)
 }
 
 export type { DiffStrategy }


### PR DESCRIPTION
In an attempt to reduce the number of errors trying to apply diffs, this change allows for a 10% edit distance difference in the search content (while still preferring the best match).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add fuzzy matching to `SearchReplaceDiffStrategy` with a 90% similarity threshold using Levenshtein distance.
> 
>   - **Behavior**:
>     - `SearchReplaceDiffStrategy` now supports fuzzy matching with a 90% similarity threshold using Levenshtein distance.
>     - `getDiffStrategy` in `DiffStrategy.ts` returns `SearchReplaceDiffStrategy` with a 0.9 threshold.
>   - **Testing**:
>     - Added tests for fuzzy matching in `search-replace.test.ts` to verify behavior with >90% similarity and failure for <90%.
>   - **Misc**:
>     - Updated version to 2.2.6 in `package.json` and `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for f3b77c9c624cb26d803196d9d68c59e23c44560b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->