### PR TITLE
Improvements to search/replace diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Roo Cline Changelog
 
+## [2.2.7]
+
+-   More fixes to search/replace diffs
+
 ## [2.2.6]
 
 -   Add a fuzzy match tolerance when applying diffs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roo-cline",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roo-cline",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",
         "@anthropic-ai/sdk": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Roo Cline",
   "description": "A fork of Cline, an autonomous coding agent, with some added experimental configuration and automation features.",
   "publisher": "RooVeterinaryInc",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "icon": "assets/icons/rocket.png",
   "galleryBanner": {
     "color": "#617A91",

--- a/src/core/diff/strategies/__tests__/search-replace.test.ts
+++ b/src/core/diff/strategies/__tests__/search-replace.test.ts
@@ -291,6 +291,329 @@ function sum(a, b) {
         })
     })
 
+    describe('line-constrained search', () => {
+        let strategy: SearchReplaceDiffStrategy
+
+        beforeEach(() => {
+            strategy = new SearchReplaceDiffStrategy()
+        })
+
+        it('should find and replace within specified line range', () => {
+            const originalContent = `
+function one() {
+    return 1;
+}
+
+function two() {
+    return 2;
+}
+
+function three() {
+    return 3;
+}
+`.trim()
+            const diffContent = `test.ts
+<<<<<<< SEARCH
+function two() {
+    return 2;
+}
+=======
+function two() {
+    return "two";
+}
+>>>>>>> REPLACE`
+
+            const result = strategy.applyDiff(originalContent, diffContent, 5, 7)
+            expect(result).toBe(`function one() {
+    return 1;
+}
+
+function two() {
+    return "two";
+}
+
+function three() {
+    return 3;
+}`)
+        })
+
+        it('should find and replace within buffer zone (5 lines before/after)', () => {
+            const originalContent = `
+function one() {
+    return 1;
+}
+
+function two() {
+    return 2;
+}
+
+function three() {
+    return 3;
+}
+`.trim()
+            const diffContent = `test.ts
+<<<<<<< SEARCH
+function three() {
+    return 3;
+}
+=======
+function three() {
+    return "three";
+}
+>>>>>>> REPLACE`
+
+            // Even though we specify lines 5-7, it should still find the match at lines 9-11
+            // because it's within the 5-line buffer zone
+            const result = strategy.applyDiff(originalContent, diffContent, 5, 7)
+            expect(result).toBe(`function one() {
+    return 1;
+}
+
+function two() {
+    return 2;
+}
+
+function three() {
+    return "three";
+}`)
+        })
+
+        it('should not find matches outside search range and buffer zone', () => {
+            const originalContent = `
+function one() {
+    return 1;
+}
+
+function two() {
+    return 2;
+}
+
+function three() {
+    return 3;
+}
+
+function four() {
+    return 4;
+}
+
+function five() {
+    return 5;
+}
+`.trim()
+            const diffContent = `test.ts
+<<<<<<< SEARCH
+function five() {
+    return 5;
+}
+=======
+function five() {
+    return "five";
+}
+>>>>>>> REPLACE`
+
+            // Searching around function two() (lines 5-7)
+            // function five() is more than 5 lines away, so it shouldn't match
+            const result = strategy.applyDiff(originalContent, diffContent, 5, 7)
+            expect(result).toBe(false)
+        })
+
+        it('should handle search range at start of file', () => {
+            const originalContent = `
+function one() {
+    return 1;
+}
+
+function two() {
+    return 2;
+}
+`.trim()
+            const diffContent = `test.ts
+<<<<<<< SEARCH
+function one() {
+    return 1;
+}
+=======
+function one() {
+    return "one";
+}
+>>>>>>> REPLACE`
+
+            const result = strategy.applyDiff(originalContent, diffContent, 1, 3)
+            expect(result).toBe(`function one() {
+    return "one";
+}
+
+function two() {
+    return 2;
+}`)
+        })
+
+        it('should handle search range at end of file', () => {
+            const originalContent = `
+function one() {
+    return 1;
+}
+
+function two() {
+    return 2;
+}
+`.trim()
+            const diffContent = `test.ts
+<<<<<<< SEARCH
+function two() {
+    return 2;
+}
+=======
+function two() {
+    return "two";
+}
+>>>>>>> REPLACE`
+
+            const result = strategy.applyDiff(originalContent, diffContent, 5, 7)
+            expect(result).toBe(`function one() {
+    return 1;
+}
+
+function two() {
+    return "two";
+}`)
+        })
+
+        it('should match specific instance of duplicate code using line numbers', () => {
+            const originalContent = `
+function processData(data) {
+    return data.map(x => x * 2);
+}
+
+function unrelatedStuff() {
+    console.log("hello");
+}
+
+// Another data processor
+function processData(data) {
+    return data.map(x => x * 2);
+}
+
+function moreStuff() {
+    console.log("world");
+}
+`.trim()
+            const diffContent = `test.ts
+<<<<<<< SEARCH
+function processData(data) {
+    return data.map(x => x * 2);
+}
+=======
+function processData(data) {
+    // Add logging
+    console.log("Processing data...");
+    return data.map(x => x * 2);
+}
+>>>>>>> REPLACE`
+
+            // Target the second instance of processData
+            const result = strategy.applyDiff(originalContent, diffContent, 10, 12)
+            expect(result).toBe(`function processData(data) {
+    return data.map(x => x * 2);
+}
+
+function unrelatedStuff() {
+    console.log("hello");
+}
+
+// Another data processor
+function processData(data) {
+    // Add logging
+    console.log("Processing data...");
+    return data.map(x => x * 2);
+}
+
+function moreStuff() {
+    console.log("world");
+}`)
+        })
+
+        it('should search from start line to end of file when only start_line is provided', () => {
+            const originalContent = `
+function one() {
+    return 1;
+}
+
+function two() {
+    return 2;
+}
+
+function three() {
+    return 3;
+}
+`.trim()
+            const diffContent = `test.ts
+<<<<<<< SEARCH
+function three() {
+    return 3;
+}
+=======
+function three() {
+    return "three";
+}
+>>>>>>> REPLACE`
+
+            // Only provide start_line, should search from there to end of file
+            const result = strategy.applyDiff(originalContent, diffContent, 8)
+            expect(result).toBe(`function one() {
+    return 1;
+}
+
+function two() {
+    return 2;
+}
+
+function three() {
+    return "three";
+}`)
+        })
+
+        it('should search from start of file to end line when only end_line is provided', () => {
+            const originalContent = `
+function one() {
+    return 1;
+}
+
+function two() {
+    return 2;
+}
+
+function three() {
+    return 3;
+}
+`.trim()
+            const diffContent = `test.ts
+<<<<<<< SEARCH
+function one() {
+    return 1;
+}
+=======
+function one() {
+    return "one";
+}
+>>>>>>> REPLACE`
+
+            // Only provide end_line, should search from start of file to there
+            const result = strategy.applyDiff(originalContent, diffContent, undefined, 4)
+            expect(result).toBe(`function one() {
+    return "one";
+}
+
+function two() {
+    return 2;
+}
+
+function three() {
+    return 3;
+}`)
+        })
+    })
+
     describe('getToolDescription', () => {
         let strategy: SearchReplaceDiffStrategy
 
@@ -311,6 +634,12 @@ function sum(a, b) {
             expect(description).toContain('>>>>>>> REPLACE')
             expect(description).toContain('<apply_diff>')
             expect(description).toContain('</apply_diff>')
+        })
+
+        it('should document start_line and end_line parameters', () => {
+            const description = strategy.getToolDescription('/test')
+            expect(description).toContain('start_line: (required) The line number where the search block starts.')
+            expect(description).toContain('end_line: (required) The line number where the search block ends.')
         })
     })
 })

--- a/src/core/diff/types.ts
+++ b/src/core/diff/types.ts
@@ -13,7 +13,9 @@ export interface DiffStrategy {
      * Apply a diff to the original content
      * @param originalContent The original file content
      * @param diffContent The diff content in the strategy's format
+     * @param startLine Optional line number where the search block starts. If not provided, searches the entire file.
+     * @param endLine Optional line number where the search block ends. If not provided, searches the entire file.
      * @returns The new content after applying the diff, or false if the diff could not be applied
      */
-    applyDiff(originalContent: string, diffContent: string): string | false
+    applyDiff(originalContent: string, diffContent: string, startLine?: number, endLine?: number): string | false
 }


### PR DESCRIPTION
Pass start/end lines into the search/replace diff to fix an bug applying diffs in the presence of duplicate code. Also, simplify the indentation code.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances search/replace diff strategy with line constraints and simplified indentation handling, updating tests accordingly.
> 
>   - **Behavior**:
>     - `applyDiff` in `search-replace.ts` now accepts `startLine` and `endLine` to constrain search range, with a 5-line buffer.
>     - Simplifies indentation handling by using matched line's indentation and relative indentation.
>   - **Tests**:
>     - Adds tests in `search-replace.test.ts` for line-constrained search, including edge cases like start/end of file and duplicate code.
>     - Updates `getToolDescription` test to include `start_line` and `end_line` parameters.
>   - **Misc**:
>     - Updates `CHANGELOG.md` and `package.json` to version 2.2.7.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 2292372e427f2044a558eaf0d9bf7cf68679235a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->