### PR TITLE
Search/replace prompt hotfix for Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Roo Cline Changelog
 
+## [2.2.9]
+
+-   Fix a bug where Gemini was including line numbers in the search/replace content
+
 ## [2.2.8]
 
 -   More work on diff editing (better matching, indentation, logging)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roo-cline",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roo-cline",
-      "version": "2.2.8",
+      "version": "2.2.9",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",
         "@anthropic-ai/sdk": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Roo Cline",
   "description": "A fork of Cline, an autonomous coding agent, with some added experimental configuration and automation features.",
   "publisher": "RooVeterinaryInc",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "icon": "assets/icons/rocket.png",
   "galleryBanner": {
     "color": "#617A91",

--- a/src/core/diff/strategies/search-replace.ts
+++ b/src/core/diff/strategies/search-replace.ts
@@ -62,6 +62,7 @@ The tool will maintain proper indentation and formatting while making changes.
 Only a single operation is allowed per tool use.
 The SEARCH section must exactly match existing content including whitespace and indentation.
 If you're not confident in the exact content to search for, use the read_file tool first to get the exact content.
+IMPORTANT: The read_file tool returns the file content with line numbers prepended to each line. However, DO NOT include line numbers in the SEARCH and REPLACE sections of the diff content.
 
 Parameters:
 - path: (required) The path of the file to modify (relative to the current working directory ${cwd})


### PR DESCRIPTION
Per https://github.com/RooVetGit/Roo-Cline/issues/113 @fridaystreet and I realized that Gemini is incorrectly including line numbers in the apply_diff content. This prompt tweak fixes it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `search-replace.ts` to exclude line numbers from Gemini's search/replace content, updates version to 2.2.9.
> 
>   - **Behavior**:
>     - Fixes bug in `search-replace.ts` where Gemini incorrectly included line numbers in search/replace content.
>     - Updates prompt to clarify exclusion of line numbers in SEARCH and REPLACE sections.
>   - **Versioning**:
>     - Updates version in `package.json` to 2.2.9.
>     - Adds entry to `CHANGELOG.md` for version 2.2.9 detailing the bug fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 0c08c0fe96967dfe24dbcf671316f50731b9c4f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->