### PR TITLE
Enter to add auto approved commands

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -42,4 +42,4 @@ jobs:
         run: npm run install:all
 
       - name: Run unit tests
-        run: npx jest
+        run: npm test

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -245,6 +245,12 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 									<VSCodeTextField
 										value={commandInput}
 										onInput={(e: any) => setCommandInput(e.target.value)}
+										onKeyDown={(e: any) => {
+											if (e.key === 'Enter') {
+												e.preventDefault()
+												handleAddCommand()
+											}
+										}}
 										placeholder="Enter command prefix (e.g., 'git ')"
 										style={{ flexGrow: 1 }}
 									/>


### PR DESCRIPTION
This is just a little thing that's been bugging me - that you can't hit enter to add auto approved commands.

I also realized that we need to update the github action to run the webview tests, I think...
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add 'Enter' key functionality to add auto-approved commands in `SettingsView` and update GitHub Actions to use `npm test`.
> 
>   - **Behavior**:
>     - In `SettingsView.tsx`, pressing 'Enter' in the command input field now triggers `handleAddCommand()` to add auto-approved commands.
>   - **GitHub Actions**:
>     - In `.github/workflows/code-qa.yml`, change test command from `npx jest` to `npm test` to align with project standards.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for e14ccf55dbfa6651c312118aa7e39e52fea90ab2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->