### PR TITLE
Add a hint that diff editing works best with latest Sonnet

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -155,7 +155,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							marginTop: "5px",
 							color: "var(--vscode-descriptionForeground)",
 						}}>
-						When enabled, Cline will be able to edit files more quickly and will automatically reject truncated full-file writes.
+						When enabled, Cline will be able to edit files more quickly and will automatically reject truncated full-file writes. Works best with the latest Claude 3.5 Sonnet model.
 					</p>
 				</div>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a hint in `SettingsView.tsx` that diff editing works best with the latest Claude 3.5 Sonnet model.
> 
>   - **UI Update**:
>     - Adds a hint in `SettingsView.tsx` that diff editing works best with the latest Claude 3.5 Sonnet model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 81aaa9c993d02d91a3dc952ae82cbb889e3e516f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->