### PR TITLE
Handle pure insertions and deletions with diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Roo Cline Changelog
 
+## [2.2.12]
+
+-   Better support for pure deletion and insertion diffs
+
 ## [2.2.11]
 
 -   Added settings checkbox for verbose diff debugging

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "roo-cline",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "roo-cline",
-      "version": "2.2.11",
+      "version": "2.2.12",
       "dependencies": {
         "@anthropic-ai/bedrock-sdk": "^0.10.2",
         "@anthropic-ai/sdk": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Roo Cline",
   "description": "A fork of Cline, an autonomous coding agent, with some added experimental configuration and automation features.",
   "publisher": "RooVeterinaryInc",
-  "version": "2.2.11",
+  "version": "2.2.12",
   "icon": "assets/icons/rocket.png",
   "galleryBanner": {
     "color": "#617A91",


### PR DESCRIPTION
Previous code didn't support empty search or replace blocks for insertion and deletion. This adds that functionality and some instructions to the prompt.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for handling empty search/replace blocks in diffs for pure insertions and deletions, with tests and documentation updates.
> 
>   - **Behavior**:
>     - Support for empty search/replace blocks in `applyDiff()` in `search-replace.ts` for insertions and deletions.
>     - Handles cases where either search or replace block is empty, allowing pure insertions or deletions.
>   - **Tests**:
>     - Added tests in `search-replace.test.ts` for deletion with empty replace block and insertion with empty search block.
>     - Tests cover multiple scenarios including nested code and file boundaries.
>   - **Documentation**:
>     - Updated `getToolDescription()` in `search-replace.ts` to include examples of insertions and deletions.
>     - Minor wording change in `system.ts` for tool use formatting instructions.
>   - **Versioning**:
>     - Updated version to 2.2.12 in `package.json` and `CHANGELOG.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 905c68dd9ea7428867264e026b0a0b5f80044881. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->