### PR TITLE
Bugfix to strip line numbers with leading space

### DIFF
--- a/src/core/diff/strategies/__tests__/search-replace.test.ts
+++ b/src/core/diff/strategies/__tests__/search-replace.test.ts
@@ -591,6 +591,26 @@ this.init();
                     expect(result.content).toBe('function test() {\n    return false;\n}\n')
                 }
             })
+
+            it('should strip line numbers with leading spaces', () => {
+                const originalContent = 'function test() {\n    return true;\n}\n'
+                const diffContent = `test.ts
+<<<<<<< SEARCH
+ 1 | function test() {
+ 2 |     return true;
+ 3 | }
+=======
+ 1 | function test() {
+ 2 |     return false;
+ 3 | }
+>>>>>>> REPLACE`
+        
+                const result = strategy.applyDiff(originalContent, diffContent)
+                expect(result.success).toBe(true)
+                if (result.success) {
+                    expect(result.content).toBe('function test() {\n    return false;\n}\n')
+                }
+            })
         
             it('should not strip when not all lines have numbers in either section', () => {
                 const originalContent = 'function test() {\n    return true;\n}\n'

--- a/src/core/diff/strategies/search-replace.ts
+++ b/src/core/diff/strategies/search-replace.ts
@@ -193,12 +193,12 @@ Result:
         // Strip line numbers from search and replace content if every line starts with a line number
         const hasLineNumbers = (content: string) => {
             const lines = content.split(/\r?\n/);
-            return lines.length > 0 && lines.every(line => /^\d+\s+\|(?!\|)/.test(line));
+            return lines.length > 0 && lines.every(line => /^\s*\d+\s+\|(?!\|)/.test(line));
         };
 
         if (hasLineNumbers(searchContent) && hasLineNumbers(replaceContent)) {
             const stripLineNumbers = (content: string) => {
-                return content.replace(/^\d+\s+\|(?!\|)/gm, '');
+                return content.replace(/^\s*\d+\s+\|(?!\|)/gm, '');
             };
 
             searchContent = stripLineNumbers(searchContent);


### PR DESCRIPTION
🤦 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bug in `SearchReplaceDiffStrategy` to strip line numbers with leading spaces, with updated regex and new test case.
> 
>   - **Behavior**:
>     - Fixes bug in `search-replace.ts` where line numbers with leading spaces were not stripped.
>     - Updates regex in `hasLineNumbers` and `stripLineNumbers` to handle leading spaces.
>   - **Tests**:
>     - Adds test case in `search-replace.test.ts` to verify line numbers with leading spaces are stripped correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 475776da98b4d9434150e2ac5008bd900ca40052. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->