### PR TITLE
fix npm run lint

### DIFF
--- a/.changeset/shaggy-moons-dance.md
+++ b/.changeset/shaggy-moons-dance.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix lint errors and change npm run lint to also run on webview-ui

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "compile": "npm run check-types && npm run lint && node esbuild.js",
     "compile-tests": "tsc -p . --outDir out",
     "install:all": "npm install && cd webview-ui && npm install",
-    "lint": "eslint src --ext ts",
+    "lint": "eslint src --ext ts && npm run lint --prefix webview-ui",
     "package": "npm run build:webview && npm run check-types && npm run lint && node esbuild.js --production",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "start:webview": "cd webview-ui && npm run start",

--- a/webview-ui/package-lock.json
+++ b/webview-ui/package-lock.json
@@ -34,7 +34,8 @@
 			},
 			"devDependencies": {
 				"@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-				"@types/vscode-webview": "^1.57.5"
+				"@types/vscode-webview": "^1.57.5",
+				"eslint": "^8.57.0"
 			}
 		},
 		"node_modules/@adobe/css-tools": {

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -31,7 +31,8 @@
 		"start": "react-scripts start",
 		"build": "node ./scripts/build-react-no-split.js",
 		"test": "react-scripts test --watchAll=false",
-		"eject": "react-scripts eject"
+		"eject": "react-scripts eject",
+		"lint": "eslint src --ext ts,tsx"
 	},
 	"eslintConfig": {
 		"extends": [
@@ -53,7 +54,8 @@
 	},
 	"devDependencies": {
 		"@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-		"@types/vscode-webview": "^1.57.5"
+		"@types/vscode-webview": "^1.57.5",
+		"eslint": "^8.57.0"
 	},
 	"jest": {
 		"transformIgnorePatterns": [

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -580,7 +580,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		}
 		// Update previous value
 		setWasStreaming(isStreaming)
-	}, [isStreaming, lastMessage, wasStreaming])
+	}, [isStreaming, lastMessage, wasStreaming, isAutoApproved])
 
 	const isBrowserSessionMessage = (message: ClineMessage): boolean => {
 		// which of visible messages are browser session messages, see above
@@ -822,7 +822,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		if (isAutoApproved(lastMessage)) {
 			handlePrimaryButtonClick()
 		}
-	}, [clineAsk, enableButtons, handlePrimaryButtonClick, alwaysAllowBrowser, alwaysAllowReadOnly, alwaysAllowWrite, alwaysAllowExecute, alwaysAllowMcp, messages, allowedCommands, mcpServers])
+	}, [clineAsk, enableButtons, handlePrimaryButtonClick, alwaysAllowBrowser, alwaysAllowReadOnly, alwaysAllowWrite, alwaysAllowExecute, alwaysAllowMcp, messages, allowedCommands, mcpServers, isAutoApproved, lastMessage])
 
 	return (
 		<div

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -479,7 +479,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		})
 	}, [modifiedMessages])
 
-	const isReadOnlyToolAction = (message: ClineMessage | undefined) => {
+	const isReadOnlyToolAction = useCallback((message: ClineMessage | undefined) => {
 		if (message?.type === "ask") {
 			if (!message.text) {
 				return true
@@ -488,9 +488,9 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			return ["readFile", "listFiles", "listFilesTopLevel", "listFilesRecursive", "listCodeDefinitionNames", "searchFiles"].includes(tool.tool)
 		}
 		return false
-	}
+	}, [])
 
-	const isWriteToolAction = (message: ClineMessage | undefined) => {
+	const isWriteToolAction = useCallback((message: ClineMessage | undefined) => {
 		if (message?.type === "ask") {
 			if (!message.text) {
 				return true
@@ -499,9 +499,9 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			return ["editedExistingFile", "appliedDiff", "newFileCreated"].includes(tool.tool)
 		}
 		return false
-	}
+	}, [])
 
-	const isMcpToolAlwaysAllowed = (message: ClineMessage | undefined) => {
+	const isMcpToolAlwaysAllowed = useCallback((message: ClineMessage | undefined) => {
 		if (message?.type === "ask" && message.ask === "use_mcp_server") {
 			if (!message.text) {
 				return true
@@ -514,9 +514,9 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			}
 		}
 		return false
-	}
+	}, [mcpServers])
 
-	const isAllowedCommand = (message: ClineMessage | undefined) => {
+	const isAllowedCommand = useCallback((message: ClineMessage | undefined) => {
 		if (message?.type === "ask") {
 			const command = message.text
 			if (!command) {
@@ -533,19 +533,32 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			})
 		}
 		return false
-	}
+	}, [allowedCommands])
 
-	const isAutoApproved = (message: ClineMessage | undefined) => {
-		if (!message || message.type !== "ask") return false
+	const isAutoApproved = useCallback(
+		(message: ClineMessage | undefined) => {
+			if (!message || message.type !== "ask") return false
 
-		return (
-			(alwaysAllowBrowser && message.ask === "browser_action_launch") ||
-			(alwaysAllowReadOnly && message.ask === "tool" && isReadOnlyToolAction(message)) ||
-			(alwaysAllowWrite && message.ask === "tool" && isWriteToolAction(message)) ||
-			(alwaysAllowExecute && message.ask === "command" && isAllowedCommand(message)) ||
-			(alwaysAllowMcp && message.ask === "use_mcp_server" && isMcpToolAlwaysAllowed(message))
-		)
-	}
+			return (
+				(alwaysAllowBrowser && message.ask === "browser_action_launch") ||
+				(alwaysAllowReadOnly && message.ask === "tool" && isReadOnlyToolAction(message)) ||
+				(alwaysAllowWrite && message.ask === "tool" && isWriteToolAction(message)) ||
+				(alwaysAllowExecute && message.ask === "command" && isAllowedCommand(message)) ||
+				(alwaysAllowMcp && message.ask === "use_mcp_server" && isMcpToolAlwaysAllowed(message))
+			)
+		},
+		[
+			alwaysAllowBrowser,
+			alwaysAllowReadOnly,
+			alwaysAllowWrite,
+			alwaysAllowExecute,
+			alwaysAllowMcp,
+			isReadOnlyToolAction,
+			isWriteToolAction,
+			isAllowedCommand,
+			isMcpToolAlwaysAllowed
+		]
+	)
 
 	useEffect(() => {
 		// Only execute when isStreaming changes from true to false

--- a/webview-ui/src/components/mcp/__tests__/McpToolRow.test.tsx
+++ b/webview-ui/src/components/mcp/__tests__/McpToolRow.test.tsx
@@ -23,7 +23,6 @@ jest.mock('@vscode/webview-ui-toolkit/react', () => ({
       <label>
         <input
           type="checkbox"
-          role="checkbox"
           checked={checked}
           onChange={onChange}
         />

--- a/webview-ui/src/components/settings/__tests__/SettingsView.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/SettingsView.test.tsx
@@ -40,7 +40,7 @@ jest.mock('@vscode/webview-ui-toolkit/react', () => ({
     />
   ),
   VSCodeTextArea: () => <textarea />,
-  VSCodeLink: () => <a />,
+  VSCodeLink: ({ children, href }: any) => <a href={href || '#'}>{children}</a>,
   VSCodeDropdown: ({ children, value, onChange }: any) => (
     <select value={value} onChange={onChange}>
       {children}


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->
## Description
npm run lint will now run in webview-ui as well

Also fix all lint warnings

## Type of change
<!-- Please ignore options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] My code follows the patterns of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context
<!-- Add any other context or screenshots about the pull request here -->

## Related Issues
<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers
<!-- @mention specific team members or individuals who should review this PR -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance linting by running it in `webview-ui` and fix lint warnings across the codebase.
> 
>   - **Linting**:
>     - Update `lint` script in `package.json` to run linting in `webview-ui`.
>     - Add `lint` script to `webview-ui/package.json`.
>   - **Code Changes**:
>     - Convert functions to `useCallback` in `ChatView.tsx` to fix lint warnings.
>     - Remove `role="checkbox"` from `McpToolRow.test.tsx` to fix lint warning.
>     - Update `VSCodeLink` mock in `SettingsView.test.tsx` to accept `children` and `href` props.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for e6b591b10d613ddf8e1d1be912115b9b861aec13. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->