### PR TITLE
Chat style fixes

### DIFF
--- a/.changeset/eight-items-unite.md
+++ b/.changeset/eight-items-unite.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+More targeted styling fix for gemini chats

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -59,6 +59,7 @@ const StyledMarkdown = styled.div`
 		max-width: calc(100vw - 20px);
 		overflow-x: auto;
 		overflow-y: hidden;
+		white-space: pre-wrap;
 	}
 
 	pre > code {

--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -54,21 +54,14 @@ const StyledMarkdown = styled.div`
 	pre {
 		background-color: ${CODE_BLOCK_BG_COLOR};
 		border-radius: 3px;
-		margin: 13px 0;
-		padding: 10px;
-		max-width: 100%;
-		white-space: pre-wrap;
-		word-break: break-word;
-		overflow-wrap: break-word;
+		margin: 13x 0;
+		padding: 10px 10px;
+		max-width: calc(100vw - 20px);
+		overflow-x: auto;
+		overflow-y: hidden;
 	}
 
 	pre > code {
-		white-space: pre-wrap;
-		word-break: break-word;
-		overflow-wrap: break-word;
-		width: 100%;
-		display: inline-block;
-
 		.hljs-deletion {
 			background-color: var(--vscode-diffEditor-removedTextBackground);
 			display: inline-block;
@@ -85,9 +78,7 @@ const StyledMarkdown = styled.div`
 		span.line:empty {
 			display: none;
 		}
-		white-space: pre-wrap;
-		word-break: break-word;
-		overflow-wrap: break-word;
+		word-wrap: break-word;
 		border-radius: 3px;
 		background-color: ${CODE_BLOCK_BG_COLOR};
 		font-size: var(--vscode-editor-font-size, var(--vscode-font-size, 12px));
@@ -125,10 +116,7 @@ const StyledMarkdown = styled.div`
 	li,
 	ol,
 	ul {
-		line-height: 1.4;
-		white-space: pre-wrap;
-		word-break: break-word;
-		overflow-wrap: break-word;
+		line-height: 1.25;
 	}
 
 	ol,


### PR DESCRIPTION
This basically reverts #154 and just adds one `white-space: pre-wrap;` to the `pre` in the sidebar.

Before:
![Screenshot 2024-12-17 at 10 55 56 PM](https://github.com/user-attachments/assets/c8a9f1e6-e2ab-4c64-84f3-1b0f559a6c4e)
![Screenshot 2024-12-17 at 10 56 20 PM](https://github.com/user-attachments/assets/1f035b68-b832-4cc1-8dad-5bc7ede3775f)

After:
![Screenshot 2024-12-17 at 10 54 54 PM](https://github.com/user-attachments/assets/fa31975c-191d-48a0-9a62-512ea45fcc3a)
![Screenshot 2024-12-17 at 10 55 13 PM](https://github.com/user-attachments/assets/8db02915-938e-4367-8e0f-d5a2a6140063)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improved chat styling in `MarkdownBlock.tsx` by adjusting code block and list styles for better readability.
> 
>   - **Styling Adjustments**:
>     - In `MarkdownBlock.tsx`, adjusted `pre` tag styles: changed `padding` to `10px 10px`, set `max-width` to `calc(100vw - 20px)`, added `overflow-x: auto` and `overflow-y: hidden`.
>     - Updated `line-height` for `li`, `ol`, `ul` to `1.25`.
>     - Removed redundant `word-break` and `overflow-wrap` properties from `pre > code` and `li, ol, ul`.
>   - **Changeset**:
>     - Added `.changeset/eight-items-unite.md` for a patch update indicating targeted styling fixes for gemini chats.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 496de0d8cb5d55a7cc8c9e2ac5483430693611d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->