### PR TITLE
Forcing preferred changelog format

### DIFF
--- a/.changeset/changelog-config.js
+++ b/.changeset/changelog-config.js
@@ -1,3 +1,5 @@
+// Doesn't fully work but '.github/scripts/overwrite_changeset_changelog.py' forces the changelog to be formatted in GHA
+
 const getReleaseLine = async (changeset) => {
   const [firstLine] = changeset.summary
     .split('\n')

--- a/.changeset/changelog-config.js
+++ b/.changeset/changelog-config.js
@@ -1,4 +1,4 @@
-// Doesn't fully work but '.github/scripts/overwrite_changeset_changelog.py' forces the changelog to be formatted in GHA
+// Half-works to simplify the format but needs 'overwrite_changeset_changelog.py' in GHA to finish formatting
 
 const getReleaseLine = async (changeset) => {
   const [firstLine] = changeset.summary
@@ -12,14 +12,9 @@ const getDependencyReleaseLine = async () => {
   return '';
 };
 
-const getReleaseSummary = async (release) => {
-  return `## [${release.newVersion}]\n\n`;
-};
-
 const changelogFunctions = {
   getReleaseLine,
   getDependencyReleaseLine,
-  getReleaseSummary,
 };
 
 module.exports = changelogFunctions;

--- a/.github/scripts/overwrite_changeset_changelog.py
+++ b/.github/scripts/overwrite_changeset_changelog.py
@@ -1,18 +1,22 @@
 """
-This script updates a specific version's release notes section in CHANGELOG.md with new content.
+This script updates a specific version's release notes section in CHANGELOG.md with new content
+or reformats existing content.
 
 The script:
-1. Takes a version number, changelog path, and new content as input from environment variables
+1. Takes a version number, changelog path, and optionally new content as input from environment variables
 2. Finds the section in the changelog for the specified version
-3. Replaces the content between the current version header and the next version header
-   (or end of file if it's the latest version) with the new content
+3. Either:
+   a) Replaces the content with new content if provided, or
+   b) Reformats existing content by:
+      - Removing the first two lines of the changeset format
+      - Ensuring version numbers are wrapped in square brackets
 4. Writes the updated changelog back to the file
 
 Environment Variables:
     CHANGELOG_PATH: Path to the changelog file (defaults to 'CHANGELOG.md')
-    VERSION: The version number to update notes for
-    PREV_VERSION: The previous version number (optional)
-    NEW_CONTENT: The new content to insert for this version
+    VERSION: The version number to update/format
+    PREV_VERSION: The previous version number (used to locate section boundaries)
+    NEW_CONTENT: Optional new content to insert for this version
 """
 
 #!/usr/bin/env python3
@@ -22,39 +26,37 @@ import os
 CHANGELOG_PATH = os.environ.get("CHANGELOG_PATH", "CHANGELOG.md")
 VERSION = os.environ['VERSION']
 PREV_VERSION = os.environ.get("PREV_VERSION", "")
-NEW_CONTENT = os.environ['NEW_CONTENT']
+NEW_CONTENT = os.environ.get("NEW_CONTENT", "")
 
-def overwrite_changelog_section(content: str):    
-    """Replace a specific version section in the changelog content.
-    
-    Args:
-        content: The full changelog content as a string
-        
-    Returns:
-        The updated changelog content with the new section
-        
-    Example:
-        >>> content = "## 1.2.0\\nOld changes\\n## 1.1.0\\nOld changes"
-        >>> NEW_CONTENT = "New changes"
-        >>> overwrite_changelog_section(content)
-        '## 1.2.0\\nNew changes\\n## 1.1.0\\nOld changes'
-    """
+def overwrite_changelog_section(changelog_text: str, new_content: str):
     # Find the section for the specified version
     version_pattern = f"## {VERSION}\n"
+    prev_version_pattern = f"## [{PREV_VERSION}]\n"
     print(f"latest version: {VERSION}")
-    notes_start_index = content.find(version_pattern) + len(version_pattern)
     print(f"prev_version: {PREV_VERSION}")
-    prev_version_pattern = f"## {PREV_VERSION}\n"
-    notes_end_index = content.find(prev_version_pattern, notes_start_index) if PREV_VERSION and prev_version_pattern in content else len(content)
-    return content[:notes_start_index] + f"{NEW_CONTENT}\n" + content[notes_end_index:]
+
+    notes_start_index = changelog_text.find(version_pattern) + len(version_pattern)
+    notes_end_index = changelog_text.find(prev_version_pattern, notes_start_index) if PREV_VERSION and prev_version_pattern in changelog_text else len(changelog_text)
+
+    if new_content:
+        return changelog_text[:notes_start_index] + f"{new_content}\n" + changelog_text[notes_end_index:]
+    else:
+        changeset_lines = changelog_text[notes_start_index:notes_end_index].split("\n")
+        # Remove the first two lines from the regular changeset format, ex: \n### Patch Changes
+        parsed_lines = "\n".join(changeset_lines[2:]) 
+        updated_changelog = changelog_text[:notes_start_index] + parsed_lines + changelog_text[notes_end_index:]
+        updated_changelog = updated_changelog.replace(f"## {VERSION}", f"## [{VERSION}]")
+        return updated_changelog
 
 with open(CHANGELOG_PATH, 'r') as f:
-    content = f.read()
+    changelog_content = f.read()
 
-new_changelog = overwrite_changelog_section(content)
-
+new_changelog = overwrite_changelog_section(changelog_content, NEW_CONTENT)
+print("----------------------------------------------------------------------------------")
 print(new_changelog)
-
+print("----------------------------------------------------------------------------------")
 # Write back to CHANGELOG.md
 with open(CHANGELOG_PATH, 'w') as f:
     f.write(new_changelog)
+
+print(f"{CHANGELOG_PATH} updated successfully!")

--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -1,9 +1,9 @@
 name: Changeset Release
-run-name: Changeset Release ${{ github.actor != 'R00-B0T' && '- Create PR' || '- Ready for Review' }}
+run-name: Changeset Release ${{ github.actor != 'R00-B0T' && '- Create PR' || '- Update Changelog' }}
 
 on:
   pull_request:
-    types: [closed, opened, synchronize, labeled]
+    types: [closed, opened, labeled]
 
 env:
   REPO_PATH: ${{ github.repository }}
@@ -76,15 +76,65 @@ jobs:
           token: ${{ secrets.CROSS_REPO_ACCESS_TOKEN }}
           fetch-depth: 0
           ref: ${{ env.GIT_REF }}
-      # Auto-approve PR
+
+      # Get current and previous versions to edit changelog entry
+      - name: Get version
+        id: get_version
+        run: |
+          VERSION=$(git show HEAD:package.json | jq -r '.version')
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          PREV_VERSION=$(git show origin/main:package.json | jq -r '.version')
+          echo "prev_version=$PREV_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION"
+          echo "prev_version=$PREV_VERSION"
+
+      # Update CHANGELOG.md with proper format
+      - name: Update Changelog Format
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'changelog-ready') }}
+        env:
+          VERSION: ${{ steps.get_version.outputs.version }}
+          PREV_VERSION: ${{ steps.get_version.outputs.prev_version }}
+        run: python .github/scripts/overwrite_changeset_changelog.py
+
+      # Commit and push changelog updates
+      - name: Push Changelog updates
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'changelog-ready') }}
+        run: |
+          git config user.name "R00-B0T"
+          git config user.email github-actions@github.com
+          git status
+          echo "Running git add and commit..."
+          git add CHANGELOG.md
+          git commit -m "Updating CHANGELOG.md format"
+          echo "--------------------------------------------------------------------------------"
+          echo "Pushing to remote..."
+          echo "--------------------------------------------------------------------------------"
+          git push
+
+      # Add label to indicate changelog has been formatted
+      - name: Add changelog-ready label
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'changelog-ready') }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['changelog-ready']
+            });
+
+      # Auto-approve PR only after it has been labeled
       - name: Auto approve PR
+        if: contains(github.event.pull_request.labels.*.name, 'changelog-ready')
         uses: hmarr/auto-approve-action@v4
         with:
           review-message: "I'm approving since it's a bump version PR"
       
       # Auto-merge PR
       - name: Automerge on PR
-        if: false # Needs enablePullRequestAutoMerge in repo settings to work
+        if: false # Needs enablePullRequestAutoMerge in repo settings to work contains(github.event.pull_request.labels.*.name, 'changelog-ready')
         run: gh pr merge --auto --merge ${{ github.event.pull_request.number }}
         env:
           GH_TOKEN: ${{ secrets.CROSS_REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->
## Description
Forcing preferred changelog format

- When a normal PR with a `changeset` file is merged `changeset-release.yml` will run and create a `Changeset version bump` PR, only the job `changeset-pr-version-bump` runs
- This triggers `changeset-release.yml` **again** but now only `changeset-pr-approve-merge` runs but doesn't run the last `Auto approve PR` step, it however updates the `CHANGELOG.md` file with our preferred format and pushes to the `Changeset version bump`, and then **labels** it `changelog-ready`
- The labeling action triggers `changeset-release.yml` again and runs **only** the `Auto approve PR` step
- Upon manual review and merging of the `changeset` PR, `marketplace-publish.yml` is triggered

## Type of change
<!-- Please ignore options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes -->
Running the python script locally and printing the formatted changes on the `CHANGELOG.md` file

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] My code follows the patterns of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context
<!-- Add any other context or screenshots about the pull request here -->

## Related Issues
<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers
<!-- @mention specific team members or individuals who should review this PR -->
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Automates changelog formatting and approval process using a Python script and GitHub Actions workflow.
> 
>   - **Script Changes**:
>     - `overwrite_changeset_changelog.py` now reformats existing changelog content if no new content is provided.
>     - Removes first two lines of changeset format and ensures version numbers are bracketed.
>   - **Workflow Changes**:
>     - `changeset-release.yml` automates changelog formatting and labeling.
>     - Adds steps to get current and previous versions, update changelog, commit changes, and push updates.
>     - Adds 'changelog-ready' label after formatting, enabling auto-approval and merge.
>   - **Changelog Config**:
>     - Removes `getReleaseSummary` function from `changelog-config.js`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for bbf7ba7995fbd76d95f2f1b9672a9fa1ca240aeb. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->