### PR TITLE
Fix gemini-2.0-flash-thinking-exp-1219 contextWindow

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -385,7 +385,7 @@ export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-thinking-ex
 export const geminiModels = {
 	"gemini-2.0-flash-thinking-exp-1219": {
 		maxTokens: 8192,
-		contextWindow: 1_048_576,
+		contextWindow: 32_767,
 		supportsImages: true,
 		supportsPromptCache: false,
 		inputPrice: 0,


### PR DESCRIPTION

## Description
Fixed context Window for gemini-2.0-flash-thinking-exp-1219
## Type of change
<!-- Please ignore options that are not relevant -->
- [x ] Bug fix (non-breaking change which fixes an issue)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `contextWindow` for `gemini-2.0-flash-thinking-exp-1219` in `api.ts` from `1_048_576` to `32_767`.
> 
>   - **Behavior**:
>     - Fixes `contextWindow` for `gemini-2.0-flash-thinking-exp-1219` in `api.ts` from `1_048_576` to `32_767`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for ffd51479c142a841ca881f7149b5a58c7496abd1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->