### PR TITLE
Default diff editing to on for new installs

### DIFF
--- a/.changeset/ninety-stingrays-give.md
+++ b/.changeset/ninety-stingrays-give.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Default diff editing to on for new installs

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -972,7 +972,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				.filter((item) => item.ts && item.task)
 				.sort((a, b) => b.ts - a.ts),
 			soundEnabled: soundEnabled ?? false,
-			diffEnabled: diffEnabled ?? false,
+			diffEnabled: diffEnabled ?? true,
 			shouldShowAnnouncement: lastShownAnnouncementId !== this.latestAnnouncementId,
 			allowedCommands,
 			soundVolume: soundVolume ?? 0.5,
@@ -1166,7 +1166,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			taskHistory,
 			allowedCommands,
 			soundEnabled: soundEnabled ?? false,
-			diffEnabled: diffEnabled ?? false,
+			diffEnabled: diffEnabled ?? true,
 			soundVolume,
 			browserLargeViewport: browserLargeViewport ?? false,
 			fuzzyMatchThreshold: fuzzyMatchThreshold ?? 1.0,

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -300,6 +300,15 @@ describe('ClineProvider', () => {
         expect(state).toHaveProperty('diffEnabled')
     })
 
+    test('diffEnabled defaults to true when not set', async () => {
+        // Mock globalState.get to return undefined for diffEnabled
+        (mockContext.globalState.get as jest.Mock).mockReturnValue(undefined)
+        
+        const state = await provider.getState()
+        
+        expect(state.diffEnabled).toBe(true)
+    })
+
     test('updates sound utility when sound setting changes', async () => {
         provider.resolveWebviewView(mockWebviewView)
 


### PR DESCRIPTION
Diff editing seems pretty stable now - I think we're ready to default it to on.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default `diffEnabled` to `true` in `ClineProvider` for new installs and update tests accordingly.
> 
>   - **Behavior**:
>     - Change default `diffEnabled` to `true` in `ClineProvider` for new installs.
>     - Update `getState()` in `ClineProvider` to reflect this change.
>   - **Tests**:
>     - Add test in `ClineProvider.test.ts` to verify `diffEnabled` defaults to `true` when not set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for b6b5c8e422b47ae7d8ef3343ba0a6f1a773b2740. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->