### PR TITLE
Tweaks to preferred language

### DIFF
--- a/.changeset/good-books-doubt.md
+++ b/.changeset/good-books-doubt.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Tweaks to preferred language (thanks @yongjer)

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1185,18 +1185,23 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				// Map VSCode locale to our supported languages
 				const langMap: { [key: string]: string } = {
 					'en': 'English',
-					'es': 'Spanish',
+					'ar': 'Arabic',
+					'pt-br': 'Brazilian Portuguese',
+					'cs': 'Czech',
 					'fr': 'French',
 					'de': 'German',
+					'hi': 'Hindi',
+					'hu': 'Hungarian',
 					'it': 'Italian',
-					'pt': 'Portuguese',
-					'zh-tw': 'Traditional Chinese',
-					'zh-cn': 'Simplified Chinese',
 					'ja': 'Japanese',
 					'ko': 'Korean',
+					'pl': 'Polish',
+					'pt': 'Portuguese',
 					'ru': 'Russian',
-					'ar': 'Arabic',
-					'hi': 'Hindi'
+					'zh-cn': 'Simplified Chinese',
+					'es': 'Spanish',
+					'zh-tw': 'Traditional Chinese',
+					'tr': 'Turkish'
 				};
 				// Return mapped language or default to English
 				return langMap[vscodeLang.split('-')[0]] ?? 'English';

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -154,18 +154,23 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 								height: "28px"
 							}}>
 							<option value="English">English</option>
-							<option value="Spanish">Spanish - Español</option>
+							<option value="Arabic">Arabic - العربية</option>
+							<option value="Brazilian Portuguese">Portuguese - Português (Brasil)</option>
+							<option value="Czech">Czech - Čeština</option>
 							<option value="French">French - Français</option>
 							<option value="German">German - Deutsch</option>
+							<option value="Hindi">Hindi - हिन्दी</option>
+							<option value="Hungarian">Hungarian - Magyar</option>
 							<option value="Italian">Italian - Italiano</option>
-							<option value="Portuguese">Portuguese - Português</option>
-							<option value="Traditional Chinese">Traditional Chinese - 繁體中文</option>
-							<option value="Simplified Chinese">Simplified Chinese - 简体中文</option>
 							<option value="Japanese">Japanese - 日本語</option>
 							<option value="Korean">Korean - 한국어</option>
+							<option value="Polish">Polish - Polski</option>
+							<option value="Portuguese">Portuguese - Português (Portugal)</option>
 							<option value="Russian">Russian - Русский</option>
-							<option value="Arabic">Arabic - العربية</option>
-							<option value="Hindi">Hindi - हिन्दी</option>
+							<option value="Simplified Chinese">Simplified Chinese - 简体中文</option>
+							<option value="Spanish">Spanish - Español</option>
+							<option value="Traditional Chinese">Traditional Chinese - 繁體中文</option>
+							<option value="Turkish">Turkish - Türkçe</option>
 						</select>
 						<p style={{
 							fontSize: "12px",


### PR DESCRIPTION
Handle the full list of VSCode locales (and release #197)

![Screenshot 2024-12-22 at 11 36 35 AM](https://github.com/user-attachments/assets/beb5f4ad-b717-4705-9a31-45d26d6fc716)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expanded language support in `ClineProvider.ts` and `SettingsView.tsx` to handle more VSCode locales.
> 
>   - **Behavior**:
>     - Expanded language mapping in `ClineProvider.ts` to include Arabic, Brazilian Portuguese, Czech, Hindi, Hungarian, Polish, Turkish, and reordered existing languages.
>     - Updated language options in `SettingsView.tsx` to match the expanded list in `ClineProvider.ts`.
>   - **Misc**:
>     - Added changeset entry in `.changeset/good-books-doubt.md` for language tweaks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 8e352ae2ab5a82908f8e185c54128a83b917e234. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->