### PR TITLE
Fixes git ref when pushing the changelog forced format

### DIFF
--- a/.github/workflows/changeset-release.yml
+++ b/.github/workflows/changeset-release.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   REPO_PATH: ${{ github.repository }}
-  GIT_REF: ${{ github.event.pull_request.head.sha }}
 
 jobs:
   # Job 1: Create version bump PR when changesets are merged to main
@@ -26,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ env.GIT_REF }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -58,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.CROSS_REPO_ACCESS_TOKEN }}
 
   # Job 2: Process version bump PR created by R00-B0T
-  changeset-pr-approve-merge:
+  changeset-pr-edit-approve:
     name: Auto approve and merge Bump version PRs
     runs-on: ubuntu-latest
     permissions:
@@ -70,12 +69,28 @@ jobs:
         github.actor == 'R00-B0T' &&
         contains(github.event.pull_request.title, 'Changeset version bump')
     steps:
+      - name: Determine checkout ref
+        id: checkout-ref
+        run: |
+          echo "Event action: ${{ github.event.action }}"
+          echo "Actor: ${{ github.actor }}"
+          echo "Head ref: ${{ github.head_ref }}"
+          echo "PR SHA: ${{ github.event.pull_request.head.sha }}"
+
+          if [[ "${{ github.event.action }}" == "opened" && "${{ github.actor }}" == "R00-B0T" ]]; then
+            echo "Using branch ref: ${{ github.head_ref }}"  
+            echo "git_ref=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+          else
+            echo "Using SHA ref: ${{ github.event.pull_request.head.sha }}"
+            echo "git_ref=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.CROSS_REPO_ACCESS_TOKEN }}
           fetch-depth: 0
-          ref: ${{ env.GIT_REF }}
+          ref: ${{ steps.checkout-ref.outputs.git_ref }}
 
       # Get current and previous versions to edit changelog entry
       - name: Get version
@@ -102,10 +117,10 @@ jobs:
         run: |
           git config user.name "R00-B0T"
           git config user.email github-actions@github.com
-          git status
           echo "Running git add and commit..."
           git add CHANGELOG.md
           git commit -m "Updating CHANGELOG.md format"
+          git status
           echo "--------------------------------------------------------------------------------"
           echo "Pushing to remote..."
           echo "--------------------------------------------------------------------------------"


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->
## Description
Fixes git ref when pushing the changelog forced format

the error was `fatal: You are not currently on a branch`, so i made changes to use the changeset PR branch when pushing the forced format.

## Type of change
<!-- Please ignore options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes -->
Reviewed by cursor
![image](https://github.com/user-attachments/assets/c01fe3a2-9a09-4b48-b320-7339b33b9e7d)
![Uploading image.png…]()


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] My code follows the patterns of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context
<!-- Add any other context or screenshots about the pull request here -->

## Related Issues
<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers
<!-- @mention specific team members or individuals who should review this PR -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes git ref determination in `changeset-release.yml` by dynamically setting the ref based on event action and actor.
> 
>   - **Behavior**:
>     - Fixes git ref determination in `.github/workflows/changeset-release.yml` by removing `GIT_REF` env variable.
>     - Dynamically determines git ref in `changeset-pr-edit-approve` job based on event action and actor.
>   - **Jobs**:
>     - Updates `changeset-pr-edit-approve` job to use `checkout-ref` step output for git ref.
>     - Renames job from `changeset-pr-approve-merge` to `changeset-pr-edit-approve`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for ba6c8bcfef0d24d59edb867719f25e60bb840c67. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->