### PR TITLE
Add the current time to the system prompt

### DIFF
--- a/.changeset/ninety-candles-wave.md
+++ b/.changeset/ninety-candles-wave.md
@@ -2,4 +2,4 @@
 "roo-cline": patch
 ---
 
-Add the current time to the system prompt
+Add the current time to the system prompt and improve browser screenshot quality (thanks @libertyteeth!)

--- a/.changeset/ninety-candles-wave.md
+++ b/.changeset/ninety-candles-wave.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add the current time to the system prompt

--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
 # Roo-Cline
 
-A fork of Cline, an autonomous coding agent, tweaked for more speed and flexibility. It’s been mainly writing itself recently, with a light touch of human guidance here and there.
+A fork of Cline, an autonomous coding agent, with some additional experimental features. It’s been mainly writing itself recently, with a light touch of human guidance here and there.
 
 ## Features
 
-- Automatically approve commands, browsing, file writing, and MCP tools
-- Faster, more targeted edits via diffs (even on big files)
-- Detects and fixes missing code chunks
-- `.clinerules` for project-specific instructions
 - Drag and drop images into chats
 - Sound effects for feedback
 - Option to use a larger 1280x800 browser
 - Quick prompt copying from history
 - OpenRouter compression support
+- Includes current time in the system prompt
 - Language selection for Cline's communication (English, Japanese, Spanish, French, German, and more)
-- Support for newer Gemini models (gemini-exp-1206, gemini-2.0-flash-exp, gemini-2.0-flash-thinking-exp-1219) and Meta 3, 3.1, and 3.2 models via AWS Bedrock
+- Support for Meta 3, 3.1, and 3.2 models via AWS Bedrock
 - Runs alongside the original Cline
 
 ## Disclaimer
@@ -85,7 +82,7 @@ Subscribe to our [Github releases](https://github.com/RooVetGit/Roo-Cline/releas
 
 ---
 
-# Cline (prev. Claude Dev) – \#1 on OpenRouter
+# Cline (prev. Claude Dev) – [#1 on OpenRouter](https://openrouter.ai/)
 
 <p align="center">
   <img src="https://media.githubusercontent.com/media/cline/cline/main/assets/docs/demo.gif" width="100%" />
@@ -95,7 +92,7 @@ Subscribe to our [Github releases](https://github.com/RooVetGit/Roo-Cline/releas
 <table>
 <tbody>
 <td align="center">
-<a href="https://marketplace.visualstudio.com/items?itemName=RooVeterinaryInc.roo-cline" target="_blank"><strong>Download on VS Marketplace</strong></a>
+<a href="https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev" target="_blank"><strong>Download on VS Marketplace</strong></a>
 </td>
 <td align="center">
 <a href="https://discord.gg/cline" target="_blank"><strong>Join the Discord</strong></a>
@@ -120,10 +117,10 @@ Thanks to [Claude 3.5 Sonnet's agentic coding capabilities](https://www-cdn.ant
     - Create and edit files + monitor linter/compiler errors along the way, letting him proactively fix issues like missing imports and syntax errors on his own.
     - Execute commands directly in your terminal and monitor their output as he works, letting him e.g., react to dev server issues after editing a file.
     - For web development tasks, Cline can launch the site in a headless browser, click, type, scroll, and capture screenshots + console logs, allowing him to fix runtime errors and visual bugs.
-4. When a task is completed, Cline will present the result to you with a terminal command like `open -a "Google Chrome" index.html`, which you run with a click of a button.
+4. When a task is completed, Cline will present the result to you with a terminal command like `open -a "Google Chrome" index.html`, which you run with a click of a button.
 
 > [!TIP]
-> Use the `CMD/CTRL + Shift + P` shortcut to open the command palette and type "Cline: Open In New Tab" to open the extension as a tab in your editor. This lets you use Cline side-by-side with your file explorer, and see how he changes your workspace more clearly.
+> Use the `CMD/CTRL + Shift + P` shortcut to open the command palette and type "Cline: Open In New Tab" to open the extension as a tab in your editor. This lets you use Cline side-by-side with your file explorer, and see how he changes your workspace more clearly.
 
 ---
 
@@ -131,7 +128,7 @@ Thanks to [Claude 3.5 Sonnet's agentic coding capabilities](https://www-cdn.ant
 
 ### Use any API and Model
 
-Cline supports API providers like OpenRouter, Anthropic, OpenAI, Google Gemini, AWS Bedrock, Azure, and GCP Vertex. You can also configure any OpenAI compatible API, or use a local model through LM Studio/Ollama. If you're using OpenRouter, the extension fetches their latest model list, allowing you to use the newest models as soon as they're available. The extension also now supports Amazon Nova and Meta Llama (3, 3.1, and 3.2) models via AWS Bedrock.
+Cline supports API providers like OpenRouter, Anthropic, OpenAI, Google Gemini, AWS Bedrock, Azure, and GCP Vertex. You can also configure any OpenAI compatible API, or use a local model through LM Studio/Ollama. If you're using OpenRouter, the extension fetches their latest model list, allowing you to use the newest models as soon as they're available.
 
 The extension also keeps track of total tokens and API usage cost for the entire task loop and individual requests, keeping you informed of spend every step of the way.
 

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2462,6 +2462,22 @@ export class Cline {
 			details += terminalDetails
 		}
 
+		// Add current time information with timezone
+		const now = new Date()
+		const formatter = new Intl.DateTimeFormat(undefined, {
+			year: 'numeric',
+			month: 'numeric',
+			day: 'numeric',
+			hour: 'numeric',
+			minute: 'numeric',
+			second: 'numeric',
+			hour12: true
+		})
+		const timeZone = formatter.resolvedOptions().timeZone
+		const timeZoneOffset = -now.getTimezoneOffset() / 60 // Convert to hours and invert sign to match conventional notation
+		const timeZoneOffsetStr = `${timeZoneOffset >= 0 ? '+' : ''}${timeZoneOffset}:00`
+		details += `\n\n# Current Time\n${formatter.format(now)} (${timeZone}, UTC${timeZoneOffsetStr})`
+
 		if (includeFileDetails) {
 			details += `\n\n# Current Working Directory (${cwd.toPosix()}) Files\n`
 			const isDesktop = arePathsEqual(cwd, path.join(os.homedir(), "Desktop"))


### PR DESCRIPTION
Based on a discussion in discord around how this would be nice for generating unique names for LLM-created files
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds current time with timezone to system prompt in `Cline.ts` for unique file name generation, with tests to verify correct formatting.
> 
>   - **Behavior**:
>     - Adds current time with timezone to system prompt in `Cline.ts` for unique file name generation.
>     - Formats time as local string with timezone and UTC offset.
>   - **Tests**:
>     - Adds test in `Cline.test.ts` to verify timezone information is included and formatted correctly in `getEnvironmentDetails()`.
>   - **Misc**:
>     - Appends time details to environment details in `getEnvironmentDetails()` function.
>     - Updates README to include current time feature in system prompt.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for f397e2bc0f1a329199164f97dc6621f8765ec006. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->