### PR TITLE
Image compression fix for 206

### DIFF
--- a/src/services/browser/BrowserSession.ts
+++ b/src/services/browser/BrowserSession.ts
@@ -134,6 +134,7 @@ export class BrowserSession {
 		let screenshotBase64 = await this.page.screenshot({
 			...options,
 			type: "webp",
+			quality: 100, // Set maximum quality to prevent compression artifacts
 		})
 		let screenshot = `data:image/webp;base64,${screenshotBase64}`
 


### PR DESCRIPTION
## Description

This "one-line code change" PR fixes compression artifacts in browser screenshots by setting WebP quality to 100%. The issue was particularly noticeable in:

1. Font rendering - especially at smaller sizes (8px)
2. 1px line tests - particularly at angles between 30-45°
3. Gradient tests - showing banding in smooth transitions

### Before/After Comparison
- Before uses the publicly-available 3.0.4
- After changed the version in package.json to 3.0.99 and rebuilt (for a visual indicator; also, to avoid collision with 3.0.5 if released during testing)

#### Font Tests
- Before (3.0.4): Significant blurring and loss of detail in 8px font, with characters appearing fuzzy and sometimes blending together
- After (3.0.99): Crisp text rendering at all sizes, with clear character separation and improved readability

#### Line Tests
- Before (3.0.4): Noticeable aliasing and stair-stepping on angled lines, particularly between 30-45°
- After (3.0.99): Clean, sharp lines at all angles with minimal aliasing and improved edge definition

#### Gradient Tests
- Before (3.0.4): Visible banding in gradients, with distinct steps visible in what should be smooth transitions
- After (3.0.99): Smooth, continuous gradients without banding artifacts

### Technical Details

The fix is to set the WebP quality parameter to 100% in BrowserSession.ts when taking screenshots:

```typescript
let screenshotBase64 = await this.page.screenshot({
    ...options,
    type: "webp",
    quality: 100, // Set maximum quality to prevent compression artifacts
})
```

This ensures maximum quality for WebP compression, eliminating visible artifacts while still maintaining reasonable file sizes through WebP's lossless compression capabilities.

### Testing

Test patterns were created to verify the improvement:
- Font rendering at various sizes (12px, 10px, 8px)
- 1px lines at angles from 0° to 45° in 1° increments
- Gradient patterns to check for banding

Screenshots were captured with both versions and compared to verify the quality improvement. The test files and comparison screenshots are:

Before (3.0.4):
- `3.0.4-2024-12-23T20-43-32-631Z-0a4444.png` - Font tests
- `3.0.4-2024-12-23T20-43-38-736Z-8d061b.png` - Line tests
- `3.0.4-2024-12-23T20-43-44-087Z-3460fb.png` - Gradient tests

After (3.0.99):
- `3.0.99-2024-12-23T20-50-56-414Z-28aa39.png` - Font tests
- `3.0.99-2024-12-23T20-51-03-293Z-1e2c01.png` - Line tests
- `3.0.99-2024-12-23T20-51-17-488Z-77e470.png` - Gradient tests

Comparisons:
- Comparison of '42' text in the 42 degree angle, zoomed to 2000%, shows extra pixels above, and changed line color below - Screenshot from 2024-12-23 16-14-20.png
- Comparison of '42' text in the 42 degree angle, zoomed to 2000%, shows extra pixels above, and changed line color below, highlights added to identify - Screenshot from 2024-12-23 16-16-34.png

## Two additional comparison images, from within GIMP, dramatically showing how many background pixels were affected by the compression by only changing one value, increasing Chroma to 100%
### Note, left is before the fix; right is after it, and appears crystal clear even with max Chroma
- Comparison of '42' text in the 42 degree angle, zoomed to 2000%, shows extra pixels above, and changed line color below, in GIMP, No change - Screenshot from 2024-12-24 12-20-05.png
- Comparison of '42' text in the 42 degree angle, zoomed to 2000%, shows extra pixels above, and changed line color below, in GIMP, Chroma to 100% - Screenshot from 2024-12-24 12-20-59.png

Note: the six Before and After images were saved as .webp files (by adding temporary code to save them, after obtaining them); however, GitHub does not support that type, so I used ImageMagick to convert to .png files.

## Checklist

- [✅] Code follows project style guidelines
- [✅] Documentation has been updated
- [✅] All tests pass
- [✅] Visual regression testing completed with before/after screenshots

## Related Issues

- In repo cline/cline: Fixes #1003 - WebP compression artifacts in browser screenshots
- Made as a separate one-line fix for this repo, for timeliness and to avoid forcing 54 other PRs to merge in

![3 0 4-2024-12-23T20-43-32-631Z-0a4444](https://github.com/user-attachments/assets/ccd260ed-d9d3-4644-b34a-ea8656ab7bf6)
![3 0 4-2024-12-23T20-43-38-736Z-8d061b](https://github.com/user-attachments/assets/5a835c9f-d9af-42ea-a008-863b4871cee1)
![3 0 4-2024-12-23T20-43-44-087Z-3460fb](https://github.com/user-attachments/assets/d532a5fd-1e3f-4830-8036-f9f2b286cc17)
![3 0 99-2024-12-23T20-50-56-414Z-28aa39](https://github.com/user-attachments/assets/316456cf-470e-4a83-8958-26de0c9e50cb)
![3 0 99-2024-12-23T20-51-03-293Z-1e2c01](https://github.com/user-attachments/assets/b3f4d629-feea-4f26-84aa-4f1ba8ae16c4)
![3 0 99-2024-12-23T20-51-17-488Z-77e470](https://github.com/user-attachments/assets/d88c8ff3-1a58-425c-8475-842f0e30990b)
![Comparison of '42' text in the 42 degree angle, zoomed to 2000%, shows extra pixels above, and changed line color below - Screenshot from 2024-12-23 16-14-20](https://github.com/user-attachments/assets/648d6f0b-dc6f-43b0-83d0-9697bfafa41d)
![Comparison of '42' text in the 42 degree angle, zoomed to 2000%, shows extra pixels above, and changed line color below, highlights added to identify - Screenshot from 2024-12-23 16-16-34](https://github.com/user-attachments/assets/2b97f2aa-3731-4492-8c9d-5d6f25886deb)
![Comparison of '42' text in the 42 degree angle, zoomed to 2000%, shows extra pixels above, and changed line color below, in GIMP, No change - Screenshot from 2024-12-24 12-20-05](https://github.com/user-attachments/assets/a3c124af-cfa4-4eba-af95-235f145f828c)
![Comparison of '42' text in the 42 degree angle, zoomed to 2000%, shows extra pixels above, and changed line color below, in GIMP, Chroma to 100% - Screenshot from 2024-12-24 12-20-59](https://github.com/user-attachments/assets/02f9015b-4c30-4fe7-ac31-60c2d206f810)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets WebP quality to 100% in `BrowserSession.ts` to fix compression artifacts in screenshots, improving font, line, and gradient rendering.
> 
>   - **Behavior**:
>     - Sets WebP quality to 100% in `BrowserSession.ts` to fix compression artifacts in screenshots.
>     - Improves font rendering, line sharpness, and gradient smoothness in screenshots.
>   - **Testing**:
>     - Conducted visual regression tests comparing versions 3.0.4 and 3.0.99.
>     - Verified improvements in font, line, and gradient rendering through test patterns and screenshots.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 72eadedcd43e7f244d329e62ca73c3709f22cf3c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->