### PR TITLE
Updated workspace tracker from Cline

### DIFF
--- a/src/integrations/workspace/WorkspaceTracker.ts
+++ b/src/integrations/workspace/WorkspaceTracker.ts
@@ -27,10 +27,8 @@ class WorkspaceTracker {
 	}
 
 	private registerListeners() {
-		// Create a file system watcher for all files
-		const watcher = vscode.workspace.createFileSystemWatcher('**')
+		const watcher = vscode.workspace.createFileSystemWatcher("**")
 
-		// Listen for file creation
 		this.disposables.push(
 			watcher.onDidCreate(async (uri) => {
 				await this.addFilePath(uri.fsPath)
@@ -38,7 +36,7 @@ class WorkspaceTracker {
 			})
 		)
 
-		// Listen for file deletion
+		// Renaming files triggers a delete and create event
 		this.disposables.push(
 			watcher.onDidDelete(async (uri) => {
 				if (await this.removeFilePath(uri.fsPath)) {
@@ -47,15 +45,6 @@ class WorkspaceTracker {
 			})
 		)
 
-		// Listen for file changes (which could include renames)
-		this.disposables.push(
-			watcher.onDidChange(async (uri) => {
-				await this.addFilePath(uri.fsPath)
-				this.workspaceDidUpdate()
-			})
-		)
-
-		// Add the watcher itself to disposables
 		this.disposables.push(watcher)
 	}
 
@@ -68,7 +57,7 @@ class WorkspaceTracker {
 			filePaths: Array.from(this.filePaths).map((file) => {
 				const relativePath = path.relative(cwd, file).toPosix()
 				return file.endsWith("/") ? relativePath + "/" : relativePath
-			}),
+			})
 		})
 	}
 

--- a/src/integrations/workspace/__tests__/WorkspaceTracker.test.ts
+++ b/src/integrations/workspace/__tests__/WorkspaceTracker.test.ts
@@ -12,7 +12,6 @@ const mockDispose = jest.fn()
 const mockWatcher = {
     onDidCreate: mockOnDidCreate.mockReturnValue({ dispose: mockDispose }),
     onDidDelete: mockOnDidDelete.mockReturnValue({ dispose: mockDispose }),
-    onDidChange: mockOnDidChange.mockReturnValue({ dispose: mockDispose }),
     dispose: mockDispose
 }
 
@@ -83,16 +82,6 @@ describe("WorkspaceTracker", () => {
         expect(mockProvider.postMessageToWebview).toHaveBeenLastCalledWith({
             type: "workspaceUpdated",
             filePaths: []
-        })
-    })
-
-    it("should handle file change events", async () => {
-        const [[callback]] = mockOnDidChange.mock.calls
-        await callback({ fsPath: "/test/workspace/changed.ts" })
-
-        expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
-            type: "workspaceUpdated",
-            filePaths: ["changed.ts"]
         })
     })
 


### PR DESCRIPTION
Bring this up to date with the latest in Cline (Saoud realized the `onDidChange` was unnecessary 🙌) 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removed unnecessary `onDidChange` listener in `WorkspaceTracker.ts`, simplifying file change handling and updated tests accordingly.
> 
>   - **Behavior**:
>     - Removed `onDidChange` listener in `WorkspaceTracker.ts` as it was unnecessary.
>     - File renames are now handled by `onDidCreate` and `onDidDelete` events.
>   - **Tests**:
>     - Removed `should handle file change events` test from `WorkspaceTracker.test.ts`.
>   - **Misc**:
>     - Minor formatting change in `WorkspaceTracker.ts` (quote style).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 2b46a307b582bf21803cab219d157030c6592295. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->