### PR TITLE
Handle case where large messages would exceed context window

### DIFF
--- a/src/core/ContextWindow.ts
+++ b/src/core/ContextWindow.ts
@@ -1,0 +1,100 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import { ModelInfo } from "../shared/api"
+
+// Rough estimate: 1 token ≈ 4 characters (this varies by model and content but works as a conservative estimate)
+export const CHARS_PER_TOKEN = 4
+
+export class ContextWindow {
+    private modelInfo: ModelInfo
+    private systemPromptSize: number
+
+    constructor(modelInfo: ModelInfo, systemPromptSize: number) {
+        this.modelInfo = modelInfo
+        this.systemPromptSize = systemPromptSize
+    }
+
+    /**
+     * Calculates the estimated token size of content blocks
+     */
+    calculateMessageSize(content: Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam | Anthropic.ToolUseBlockParam | Anthropic.ToolResultBlockParam>): number {
+        return content.reduce<number>((total, block) => {
+            switch (block.type) {
+                case "text": {
+                    // Rough estimate: 1 token ≈ 4 characters
+                    const textBlock = block as Anthropic.TextBlockParam
+                    return total + Math.ceil(textBlock.text.length / CHARS_PER_TOKEN)
+                }
+                case "tool_use": {
+                    // Tool use blocks include name and parameters
+                    const toolBlock = block as Anthropic.ToolUseBlockParam
+                    const paramSize = Object.entries(toolBlock.input || {}).reduce<number>((sum, [key, value]) => 
+                        sum + Math.ceil((key + String(value)).length / CHARS_PER_TOKEN), 0)
+                    return total + Math.ceil(toolBlock.name.length / CHARS_PER_TOKEN) + paramSize + 100 // Extra tokens for structure
+                }
+                case "tool_result": {
+                    // Tool results can be string or array of blocks
+                    const toolBlock = block as Anthropic.ToolResultBlockParam
+                    if (typeof toolBlock.content === "string") {
+                        return total + Math.ceil(toolBlock.content.length / CHARS_PER_TOKEN)
+                    }
+                    if (Array.isArray(toolBlock.content)) {
+                        return total + toolBlock.content.reduce<number>((sum, contentBlock) => {
+                            if (contentBlock.type === "text") {
+                                return sum + Math.ceil(contentBlock.text.length / CHARS_PER_TOKEN)
+                            }
+                            return sum + 500 // Base size for non-text content blocks
+                        }, 0)
+                    }
+                    return total + 500 // Default size for unknown content
+                }
+                case "image":
+                default:
+                    // Conservative estimate for images and unknown types
+                    return total + 500
+            }
+        }, 0)
+    }
+
+    /**
+     * Gets the maximum allowed message size based on context window and other constraints
+     */
+    private getMaxAllowedSize(): number {
+        const contextWindow = this.modelInfo.contextWindow || 128_000
+        const responseBuffer = this.modelInfo.maxTokens ?? 4000
+        return contextWindow - this.systemPromptSize - responseBuffer
+    }
+
+    /**
+     * Checks if a message would exceed the context window limits
+     * Returns an error message if the message is too large, undefined otherwise
+     */
+    validateMessageSize(messageSize: number): string | undefined {
+        const maxAllowedSize = this.getMaxAllowedSize()
+
+        if (messageSize >= maxAllowedSize) {
+            return `The message is too large for the model's available space (${messageSize} estimated tokens > ${maxAllowedSize} tokens, where ${this.systemPromptSize} tokens are used by system prompt and ${this.modelInfo.maxTokens ?? 4000} tokens reserved for response). Please hit Cancel and try breaking up the task into smaller steps.`
+        }
+
+        return undefined
+    }
+
+    /**
+     * Checks if the conversation history size exceeds the context window
+     * Returns true if truncation is needed
+     */
+    shouldTruncateHistory(messages: Array<Anthropic.MessageParam>): boolean {
+        let totalSize = 0
+        for (const message of messages) {
+            if (Array.isArray(message.content)) {
+                totalSize += this.calculateMessageSize(message.content)
+            } else {
+                totalSize += Math.ceil(message.content.length / CHARS_PER_TOKEN)
+            }
+        }
+        
+        const maxAllowedSize = this.getMaxAllowedSize()
+        
+        // Truncate when total size exceeds available space
+        return totalSize >= maxAllowedSize
+    }
+}

--- a/src/core/__tests__/ContextWindow.test.ts
+++ b/src/core/__tests__/ContextWindow.test.ts
@@ -1,0 +1,154 @@
+import { ContextWindow } from '../ContextWindow'
+import { ModelInfo } from '../../shared/api'
+import { Anthropic } from '@anthropic-ai/sdk'
+
+describe('ContextWindow', () => {
+    let contextWindow: ContextWindow
+    let mockModelInfo: ModelInfo
+
+    beforeEach(() => {
+        mockModelInfo = {
+            contextWindow: 128000,
+            maxTokens: 4000,
+            supportsComputerUse: true,
+            supportsPromptCache: false,
+            supportsImages: true,
+            inputPrice: 0,
+            outputPrice: 0,
+        }
+
+        // System prompt is 2000 tokens
+        const systemPromptSize = 2000
+        contextWindow = new ContextWindow(mockModelInfo, systemPromptSize)
+    })
+
+    describe('Message Size Calculation', () => {
+        it('should correctly estimate token size for text content', () => {
+            const content: Anthropic.TextBlockParam[] = [{
+                type: 'text',
+                text: 'a'.repeat(4000) // Should be roughly 1000 tokens
+            }]
+
+            const size = contextWindow.calculateMessageSize(content)
+            expect(size).toBe(1000)
+        })
+
+        it('should handle non-text content blocks appropriately', () => {
+            const content: Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam> = [
+                {
+                    type: 'text',
+                    text: 'Regular text' // 11 chars ≈ 3 tokens
+                },
+                {
+                    type: 'image',
+                    source: {
+                        type: 'base64',
+                        data: 'test-image-data',
+                        media_type: 'image/jpeg'
+                    }
+                }
+            ]
+
+            const size = contextWindow.calculateMessageSize(content)
+            // 3 tokens for text + 500 tokens base size for image
+            expect(size).toBe(503)
+        })
+    })
+
+    describe('Message Size Validation', () => {
+        it('should accept messages within context window limits', () => {
+            const content: Anthropic.TextBlockParam[] = [{
+                type: 'text',
+                text: 'a'.repeat(4000) // Should be roughly 1000 tokens
+            }]
+
+            const size = contextWindow.calculateMessageSize(content)
+            const error = contextWindow.validateMessageSize(size)
+            expect(error).toBeUndefined()
+        })
+
+        it('should reject messages that exceed context window limits', () => {
+            // Available space = context window (128000) - system prompt (2000) - response buffer (4000) = 122000
+            // So a message of 123000 tokens should be rejected
+            const size = 123000
+            const error = contextWindow.validateMessageSize(size)
+            expect(error).toBeDefined()
+            expect(error).toContain('too large')
+            expect(error).toContain('system prompt')
+            expect(error).toContain('reserved for response')
+        })
+    })
+
+    describe('History Truncation', () => {
+        it('should recommend truncation when message size exceeds available space', () => {
+            // Available space = context window (128000) - system prompt (2000) - response buffer (4000) = 122000
+            const messages: Anthropic.MessageParam[] = [
+                { role: "user", content: 'a'.repeat(400000) }, // ~100k tokens
+                { role: "assistant", content: 'b'.repeat(100000) } // ~25k tokens
+            ]
+            const shouldTruncate = contextWindow.shouldTruncateHistory(messages)
+            expect(shouldTruncate).toBe(true)
+        })
+
+        it('should not recommend truncation for normal message sizes', () => {
+            const messages: Anthropic.MessageParam[] = [
+                { role: "user", content: 'a'.repeat(4000) }, // ~1k tokens
+                { role: "assistant", content: 'b'.repeat(4000) } // ~1k tokens
+            ]
+            const shouldTruncate = contextWindow.shouldTruncateHistory(messages)
+            expect(shouldTruncate).toBe(false)
+        })
+
+        it('should handle array content in messages', () => {
+            const messages: Anthropic.MessageParam[] = [
+                {
+                    role: "user",
+                    content: [
+                        { type: "text", text: 'a'.repeat(400000) } as Anthropic.TextBlockParam, // ~100k tokens
+                        { type: "text", text: 'b'.repeat(100000) } as Anthropic.TextBlockParam  // ~25k tokens
+                    ]
+                }
+            ]
+            const shouldTruncate = contextWindow.shouldTruncateHistory(messages)
+            expect(shouldTruncate).toBe(true)
+        })
+
+        it('should handle empty history', () => {
+            const shouldTruncate = contextWindow.shouldTruncateHistory([])
+            expect(shouldTruncate).toBe(false)
+        })
+    })
+
+    describe('Different Model Configurations', () => {
+        it('should handle models with smaller context windows', () => {
+            const smallModelInfo = {
+                ...mockModelInfo,
+                contextWindow: 8000,
+                maxTokens: 1000
+            }
+            const smallContextWindow = new ContextWindow(smallModelInfo, 2000)
+
+            // Available space = context window (8000) - system prompt (2000) - response buffer (1000) = 5000
+            // So a message of 6000 tokens should be rejected
+            const size = 6000
+            const error = smallContextWindow.validateMessageSize(size)
+            expect(error).toBeDefined()
+            expect(error).toContain('too large')
+        })
+
+        it('should handle models with larger response buffers', () => {
+            const largeBufferModelInfo = {
+                ...mockModelInfo,
+                maxTokens: 8000
+            }
+            const largeBufferContextWindow = new ContextWindow(largeBufferModelInfo, 2000)
+
+            // Available space = context window (128000) - system prompt (2000) - response buffer (8000) = 118000
+            // So a message of 119000 tokens should be rejected
+            const size = 119000
+            const error = largeBufferContextWindow.validateMessageSize(size)
+            expect(error).toBeDefined()
+            expect(error).toContain('reserved for response')
+        })
+    })
+})


### PR DESCRIPTION
Attempt to fix the issue where long messages overflow the context window, leaving the user stuck.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `ContextWindow` class to manage message sizes in `Cline`, with tests for validation and truncation logic.
> 
>   - **Behavior**:
>     - Introduces `ContextWindow` class in `ContextWindow.ts` to manage message size and context window limits.
>     - Updates `Cline` class in `Cline.ts` to use `ContextWindow` for message size validation and history truncation.
>     - Handles large messages by checking if they exceed the context window and prompts user to retry if necessary.
>   - **Testing**:
>     - Adds `ContextWindow.test.ts` to test message size calculation, validation, and history truncation logic.
>     - Tests various scenarios including different model configurations and token types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 4ea817bd67023e8474936a051bd46f559b8c38e9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->