### PR TITLE
Add a button to delete user messages

### DIFF
--- a/.changeset/khaki-pets-approve.md
+++ b/.changeset/khaki-pets-approve.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add a button to delete user messages

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A fork of Cline, an autonomous coding agent, with some additional experimental f
 ## Experimental Features
 
 - Drag and drop images into chats
+- Delete messages from chats
 - "Enhance prompt" button (OpenRouter models only for now)
 - Sound effects for feedback
 - Option to use browsers of different sizes and adjust screenshot quality

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -47,6 +47,7 @@ export interface WebviewMessage {
 		| "enhancePrompt"
 		| "enhancedPrompt"
 		| "draggedImages"
+		| "deleteMessage"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/webview-ui/src/components/chat/BrowserSessionRow.tsx
+++ b/webview-ui/src/components/chat/BrowserSessionRow.tsx
@@ -20,6 +20,7 @@ interface BrowserSessionRowProps {
 	lastModifiedMessage?: ClineMessage
 	isLast: boolean
 	onHeightChange: (isTaller: boolean) => void
+	isStreaming: boolean
 }
 
 const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
@@ -408,6 +409,7 @@ const BrowserSessionRow = memo((props: BrowserSessionRowProps) => {
 interface BrowserSessionRowContentProps extends Omit<BrowserSessionRowProps, "messages"> {
 	message: ClineMessage
 	setMaxActionHeight: (height: number) => void
+	isStreaming: boolean
 }
 
 const BrowserSessionRowContent = ({
@@ -417,6 +419,7 @@ const BrowserSessionRowContent = ({
 	lastModifiedMessage,
 	isLast,
 	setMaxActionHeight,
+	isStreaming,
 }: BrowserSessionRowContentProps) => {
 	const headerStyle: React.CSSProperties = {
 		display: "flex",
@@ -443,6 +446,7 @@ const BrowserSessionRowContent = ({
 								}}
 								lastModifiedMessage={lastModifiedMessage}
 								isLast={isLast}
+								isStreaming={isStreaming}
 							/>
 						</div>
 					)

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1,4 +1,4 @@
-import { VSCodeBadge, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeBadge, VSCodeButton, VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react"
 import deepEqual from "fast-deep-equal"
 import React, { memo, useEffect, useMemo, useRef } from "react"
 import { useSize } from "react-use"
@@ -27,6 +27,7 @@ interface ChatRowProps {
 	lastModifiedMessage?: ClineMessage
 	isLast: boolean
 	onHeightChange: (isTaller: boolean) => void
+	isStreaming: boolean
 }
 
 interface ChatRowContentProps extends Omit<ChatRowProps, "onHeightChange"> {}
@@ -75,6 +76,7 @@ export const ChatRowContent = ({
 	onToggleExpand,
 	lastModifiedMessage,
 	isLast,
+	isStreaming,
 }: ChatRowContentProps) => {
 	const { mcpServers } = useExtensionState()
 	const [cost, apiReqCancelReason, apiReqStreamingFailedMessage] = useMemo(() => {
@@ -475,10 +477,9 @@ export const ChatRowContent = ({
 									msUserSelect: "none",
 								}}
 								onClick={onToggleExpand}>
-								<div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+								<div style={{ display: "flex", alignItems: "center", gap: "10px", flexGrow: 1 }}>
 									{icon}
 									{title}
-									{/* Need to render this everytime since it affects height of row by 2px */}
 									<VSCodeBadge style={{ opacity: cost != null && cost > 0 ? 1 : 0 }}>
 										${Number(cost || 0)?.toFixed(4)}
 									</VSCodeBadge>
@@ -570,7 +571,29 @@ export const ChatRowContent = ({
 								whiteSpace: "pre-line",
 								wordWrap: "break-word",
 							}}>
-							<span style={{ display: "block" }}>{highlightMentions(message.text)}</span>
+							<div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "10px" }}>
+								<span style={{ display: "block", flexGrow: 1 }}>{highlightMentions(message.text)}</span>
+								<VSCodeButton
+									appearance="icon"
+									style={{
+										padding: "3px",
+										flexShrink: 0,
+										height: "24px",
+										marginTop: "-6px",
+										marginRight: "-6px"
+									}}
+									disabled={isStreaming}
+									onClick={(e) => {
+										e.stopPropagation();
+										vscode.postMessage({
+											type: "deleteMessage",
+											value: message.ts
+										});
+									}}
+								>
+									<span className="codicon codicon-trash"></span>
+								</VSCodeButton>
+							</div>
 							{message.images && message.images.length > 0 && (
 								<Thumbnails images={message.images} style={{ marginTop: "8px" }} />
 							)}

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -787,6 +787,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						isLast={index === groupedMessages.length - 1}
 						lastModifiedMessage={modifiedMessages.at(-1)}
 						onHeightChange={handleRowHeightChange}
+						isStreaming={isStreaming}
 						// Pass handlers for each message in the group
 						isExpanded={(messageTs: number) => expandedRows[messageTs] ?? false}
 						onToggleExpand={(messageTs: number) => {
@@ -809,10 +810,11 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 					lastModifiedMessage={modifiedMessages.at(-1)}
 					isLast={index === groupedMessages.length - 1}
 					onHeightChange={handleRowHeightChange}
+					isStreaming={isStreaming}
 				/>
 			)
 		},
-		[expandedRows, modifiedMessages, groupedMessages.length, toggleRowExpansion, handleRowHeightChange],
+		[expandedRows, modifiedMessages, groupedMessages.length, handleRowHeightChange, isStreaming, toggleRowExpansion],
 	)
 
 	useEffect(() => {


### PR DESCRIPTION
Before deletion:
<img width="443" alt="Screenshot 2024-12-30 at 3 15 01 PM" src="https://github.com/user-attachments/assets/d80172ed-2829-42f8-ba19-b215cc6c23cf" />

After deletion:
<img width="438" alt="Screenshot 2024-12-30 at 3 15 10 PM" src="https://github.com/user-attachments/assets/a4a1cf04-a7e8-4303-aa53-8b08f49066f9" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a delete button to user messages, allowing deletion of a message and subsequent messages after confirmation.
> 
>   - **Behavior**:
>     - Adds a delete button to user messages in `ChatRow.tsx` and `BrowserSessionRow.tsx`.
>     - On click, prompts user for confirmation and deletes the message and subsequent messages in `ClineProvider.ts`.
>   - **Webview Communication**:
>     - Adds `deleteMessage` type to `WebviewMessage.ts` for message handling.
>   - **UI Components**:
>     - Updates `ChatRow.tsx` and `BrowserSessionRow.tsx` to include delete button and handle its click event.
>   - **Documentation**:
>     - Updates `README.md` to include the new feature of deleting messages.
>   - **Tests**:
>     - Adds tests in `ClineProvider.test.ts` to verify message deletion behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 90ed3a4582aadcbd27cc51766c35acf4f815a4ac. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->