### PR TITLE
Improvements to terminal output when executing commands

### DIFF
--- a/.changeset/early-dodos-know.md
+++ b/.changeset/early-dodos-know.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add a setting to control the number of terminal output lines to pass to the model when executing commands

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A fork of Cline, an autonomous coding agent, with some additional experimental f
 - Per-tool MCP auto-approval
 - Enable/disable MCP servers
 - Configurable delay after auto-writes to allow diagnostics to detect potential problems
+- Control the number of terminal output lines to pass to the model when executing commands
 - Runs alongside the original Cline
 
 ## Disclaimer

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -76,6 +76,7 @@ type GlobalStateKey =
 	| "fuzzyMatchThreshold"
 	| "preferredLanguage" // Language setting for Cline's communication
 	| "writeDelayMs"
+	| "terminalOutputLineLimit"
 
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",
@@ -642,6 +643,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						await this.updateGlobalState("writeDelayMs", message.value)
 						await this.postStateToWebview()
 						break
+					case "terminalOutputLineLimit":
+						await this.updateGlobalState("terminalOutputLineLimit", message.value)
+						await this.postStateToWebview()
+						break
 					case "deleteMessage": {
 						const answer = await vscode.window.showInformationMessage(
 							"Are you sure you want to delete this message and all subsequent messages?",
@@ -1046,6 +1051,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			screenshotQuality,
 			preferredLanguage,
 			writeDelayMs,
+			terminalOutputLineLimit,
 		} = await this.getState()
 		
 		const allowedCommands = vscode.workspace
@@ -1075,6 +1081,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			screenshotQuality: screenshotQuality ?? 75,
 			preferredLanguage: preferredLanguage ?? 'English',
 			writeDelayMs: writeDelayMs ?? 1000,
+			terminalOutputLineLimit: terminalOutputLineLimit ?? 500,
 		}
 	}
 
@@ -1174,6 +1181,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			preferredLanguage,
 			writeDelayMs,
 			screenshotQuality,
+			terminalOutputLineLimit,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
 			this.getGlobalState("apiModelId") as Promise<string | undefined>,
@@ -1218,6 +1226,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("preferredLanguage") as Promise<string | undefined>,
 			this.getGlobalState("writeDelayMs") as Promise<number | undefined>,
 			this.getGlobalState("screenshotQuality") as Promise<number | undefined>,
+			this.getGlobalState("terminalOutputLineLimit") as Promise<number | undefined>,
 		])
 
 		let apiProvider: ApiProvider
@@ -1279,6 +1288,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			screenshotQuality: screenshotQuality ?? 75,
 			fuzzyMatchThreshold: fuzzyMatchThreshold ?? 1.0,
 			writeDelayMs: writeDelayMs ?? 1000,
+			terminalOutputLineLimit: terminalOutputLineLimit ?? 500,
 			preferredLanguage: preferredLanguage ?? (() => {
 				// Get VSCode's locale setting
 				const vscodeLang = vscode.env.language;

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -16,8 +16,11 @@ export class TerminalRegistry {
 	static createTerminal(cwd?: string | vscode.Uri | undefined): TerminalInfo {
 		const terminal = vscode.window.createTerminal({
 			cwd,
-			name: "Cline",
-			iconPath: new vscode.ThemeIcon("robot"),
+			name: "Roo Cline",
+			iconPath: new vscode.ThemeIcon("rocket"),
+			env: {
+				PAGER: "cat"
+			}
 		})
 		const newInfo: TerminalInfo = {
 			terminal,

--- a/src/integrations/terminal/__tests__/TerminalRegistry.test.ts
+++ b/src/integrations/terminal/__tests__/TerminalRegistry.test.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode"
+import { TerminalRegistry } from "../TerminalRegistry"
+
+// Mock vscode.window.createTerminal
+const mockCreateTerminal = jest.fn()
+jest.mock("vscode", () => ({
+  window: {
+    createTerminal: (...args: any[]) => {
+      mockCreateTerminal(...args)
+      return {
+        exitStatus: undefined,
+      }
+    },
+  },
+  ThemeIcon: jest.fn(),
+}))
+
+describe("TerminalRegistry", () => {
+  beforeEach(() => {
+    mockCreateTerminal.mockClear()
+  })
+
+  describe("createTerminal", () => {
+    it("creates terminal with PAGER set to cat", () => {
+      TerminalRegistry.createTerminal("/test/path")
+
+      expect(mockCreateTerminal).toHaveBeenCalledWith({
+        cwd: "/test/path",
+        name: "Roo Cline",
+        iconPath: expect.any(Object),
+        env: {
+          PAGER: "cat"
+        }
+      })
+    })
+  })
+})

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -61,6 +61,7 @@ export interface ExtensionState {
 	fuzzyMatchThreshold?: number
 	preferredLanguage: string
 	writeDelayMs: number
+	terminalOutputLineLimit?: number
 }
 
 export interface ClineMessage {

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -48,6 +48,7 @@ export interface WebviewMessage {
 		| "enhancedPrompt"
 		| "draggedImages"
 		| "deleteMessage"
+		| "terminalOutputLineLimit"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -46,6 +46,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		setWriteDelayMs,
 		screenshotQuality,
 		setScreenshotQuality,
+		terminalOutputLineLimit,
+		setTerminalOutputLineLimit,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
@@ -76,6 +78,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			vscode.postMessage({ type: "preferredLanguage", text: preferredLanguage })
 			vscode.postMessage({ type: "writeDelayMs", value: writeDelayMs })
 			vscode.postMessage({ type: "screenshotQuality", value: screenshotQuality ?? 75 })
+			vscode.postMessage({ type: "terminalOutputLineLimit", value: terminalOutputLineLimit ?? 500 })
 			onDone()
 		}
 	}
@@ -207,6 +210,31 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							color: "var(--vscode-descriptionForeground)",
 						}}>
 						These instructions are added to the end of the system prompt sent with every request. Custom instructions set in .clinerules and .cursorrules in the working directory are also included.
+					</p>
+				</div>
+
+				<div style={{ marginBottom: 5 }}>
+					<div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
+						<span style={{ fontWeight: "500", minWidth: '150px' }}>Terminal output limit</span>
+						<input
+							type="range"
+							min="100"
+							max="5000"
+							step="100"
+							value={terminalOutputLineLimit ?? 500}
+							onChange={(e) => setTerminalOutputLineLimit(parseInt(e.target.value))}
+							style={{
+								flexGrow: 1,
+								accentColor: 'var(--vscode-button-background)',
+								height: '2px'
+							}}
+						/>
+						<span style={{ minWidth: '45px', textAlign: 'left' }}>
+							{terminalOutputLineLimit ?? 500}
+						</span>
+					</div>
+					<p style={{ fontSize: "12px", marginTop: "5px", color: "var(--vscode-descriptionForeground)" }}>
+						Maximum number of lines to include in terminal output when executing commands. When exceeded lines will be removed from the middle, saving tokens.
 					</p>
 				</div>
 
@@ -431,7 +459,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 					<div style={{ marginBottom: 10 }}>
 						<div style={{ marginBottom: 15 }}>
 							<h3 style={{ color: "var(--vscode-foreground)", margin: 0, marginBottom: 15 }}>Browser Settings</h3>
-							<label style={{ fontWeight: "500", display: "block", marginBottom: 5 }}>Viewport Size</label>
+							<label style={{ fontWeight: "500", display: "block", marginBottom: 5 }}>Viewport size</label>
 							<select
 								value={browserViewportSize}
 								onChange={(e) => setBrowserViewportSize(e.target.value)}
@@ -460,7 +488,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 
 						<div style={{ marginBottom: 15 }}>
 							<div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
-								<span style={{ fontWeight: "500", minWidth: '100px' }}>Screenshot Quality</span>
+								<span style={{ fontWeight: "500", minWidth: '100px' }}>Screenshot quality</span>
 								<input
 									type="range"
 									min="1"

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -39,6 +39,8 @@ export interface ExtensionStateContextType extends ExtensionState {
 	setWriteDelayMs: (value: number) => void
 	screenshotQuality?: number
 	setScreenshotQuality: (value: number) => void
+	terminalOutputLineLimit?: number
+	setTerminalOutputLineLimit: (value: number) => void
 }
 
 export const ExtensionStateContext = createContext<ExtensionStateContextType | undefined>(undefined)
@@ -58,6 +60,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		writeDelayMs: 1000,
 		browserViewportSize: "900x600",
 		screenshotQuality: 75,
+		terminalOutputLineLimit: 500,
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)
@@ -176,6 +179,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setPreferredLanguage: (value) => setState((prevState) => ({ ...prevState, preferredLanguage: value })),
 		setWriteDelayMs: (value) => setState((prevState) => ({ ...prevState, writeDelayMs: value })),
 		setScreenshotQuality: (value) => setState((prevState) => ({ ...prevState, screenshotQuality: value })),
+		setTerminalOutputLineLimit: (value) => setState((prevState) => ({ ...prevState, terminalOutputLineLimit: value })),
 	}
 
 	return <ExtensionStateContext.Provider value={contextValue}>{children}</ExtensionStateContext.Provider>


### PR DESCRIPTION
- Set an environment variable to export PAGER=cat per https://github.com/cline/cline/issues/1045 to avoid waiting for a pager when running commands like `git show`
- Add a slider to control how many lines of output to consider when running terminal commands (`npm test` for instance generates a ton of terminal spam from its progress bar)

<img width="415" alt="Screenshot 2024-12-30 at 11 07 36 PM" src="https://github.com/user-attachments/assets/a0b792d0-6cb5-4b7e-bc16-898dba56f6be" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance terminal command execution by setting `PAGER=cat` and adding a terminal output line limit slider in settings.
> 
>   - **Behavior**:
>     - Set `PAGER=cat` in `TerminalRegistry` to avoid pager wait in terminal commands.
>     - Add slider in `SettingsView.tsx` to control terminal output line limit, default 500 lines.
>   - **Core Changes**:
>     - Modify `executeCommandTool()` in `Cline.ts` to use `terminalOutputLineLimit` for output formatting.
>     - Update `ClineProvider.ts` to handle `terminalOutputLineLimit` state and messages.
>   - **UI and Context**:
>     - Add `terminalOutputLineLimit` to `ExtensionState` and `WebviewMessage`.
>     - Update `SettingsView.tsx` to include terminal output limit slider.
>     - Adjust `ExtensionStateContext.tsx` to manage `terminalOutputLineLimit`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for c8b8eff1470d9215456a5e79a383e6da3cb6d89b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->