### PR TITLE
Pass clean conversation history to API for Anthropic

### DIFF
--- a/.changeset/stupid-pears-help.md
+++ b/.changeset/stupid-pears-help.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Hotfix

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -807,7 +807,9 @@ export class Cline {
 			}
 		}
 
-		const stream = this.api.createMessage(systemPrompt, this.apiConversationHistory)
+		// Convert to Anthropic.MessageParam by spreading only the API-required properties
+		const cleanConversationHistory = this.apiConversationHistory.map(({ role, content }) => ({ role, content }))
+		const stream = this.api.createMessage(systemPrompt, cleanConversationHistory)
 		const iterator = stream[Symbol.asyncIterator]()
 
 		try {


### PR DESCRIPTION
Bugfix from #251 - need to make sure the API is clean for Anthropic to avoid "Extra inputs are not permitted" error
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Anthropic API error by cleaning conversation history in `Cline.ts`.
> 
>   - **Bugfix**:
>     - Fixes "Extra inputs are not permitted" error in Anthropic API by cleaning conversation history in `Cline.ts`.
>     - Maps `apiConversationHistory` to `cleanConversationHistory` with only `role` and `content` properties.
>   - **Misc**:
>     - Adds a changeset file `stupid-pears-help.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 26f7ba07c2ab8d9714de5d00a81c9be75782e760. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->