### PR TITLE
Fix fuzzy match slider

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1052,6 +1052,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			preferredLanguage,
 			writeDelayMs,
 			terminalOutputLineLimit,
+			fuzzyMatchThreshold,
 		} = await this.getState()
 		
 		const allowedCommands = vscode.workspace
@@ -1082,6 +1083,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			preferredLanguage: preferredLanguage ?? 'English',
 			writeDelayMs: writeDelayMs ?? 1000,
 			terminalOutputLineLimit: terminalOutputLineLimit ?? 500,
+			fuzzyMatchThreshold: fuzzyMatchThreshold ?? 1.0,
 		}
 	}
 

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -257,7 +257,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 								<span style={{ fontWeight: "500", minWidth: '100px' }}>Match precision</span>
 								<input
 									type="range"
-									min="0.9"
+									min="0.8"
 									max="1"
 									step="0.005"
 									value={fuzzyMatchThreshold ?? 1.0}


### PR DESCRIPTION
https://github.com/RooVetGit/Roo-Cline/issues/257

Also change the minimum to 0.8 per some people's request
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes fuzzy match slider by adjusting its minimum value and handling `fuzzyMatchThreshold` in state management.
> 
>   - **Behavior**:
>     - Adjusts `fuzzyMatchThreshold` default to 1.0 in `ClineProvider.ts`.
>     - Changes minimum value of fuzzy match slider to 0.8 in `SettingsView.tsx`.
>   - **State Management**:
>     - Adds `fuzzyMatchThreshold` to state retrieval in `ClineProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for cec623ada42f98bc7c22b65904048f81eac00ed2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->