### PR TITLE
Fix 'allow stream options' checkbox

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -63,6 +63,7 @@ type GlobalStateKey =
 	| "lmStudioBaseUrl"
 	| "anthropicBaseUrl"
 	| "azureApiVersion"
+	| "includeStreamOptions"
 	| "openRouterModelId"
 	| "openRouterModelInfo"
 	| "openRouterUseMiddleOutTransform"
@@ -421,6 +422,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								geminiApiKey,
 								openAiNativeApiKey,
 								azureApiVersion,
+								includeStreamOptions,
 								openRouterModelId,
 								openRouterModelInfo,
 								openRouterUseMiddleOutTransform,
@@ -448,6 +450,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 							await this.storeSecret("openAiNativeApiKey", openAiNativeApiKey)
 							await this.storeSecret("deepSeekApiKey", message.apiConfiguration.deepSeekApiKey)
 							await this.updateGlobalState("azureApiVersion", azureApiVersion)
+							await this.updateGlobalState("includeStreamOptions", includeStreamOptions)
 							await this.updateGlobalState("openRouterModelId", openRouterModelId)
 							await this.updateGlobalState("openRouterModelInfo", openRouterModelInfo)
 							await this.updateGlobalState("openRouterUseMiddleOutTransform", openRouterUseMiddleOutTransform)
@@ -1163,6 +1166,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			openAiNativeApiKey,
 			deepSeekApiKey,
 			azureApiVersion,
+			includeStreamOptions,
 			openRouterModelId,
 			openRouterModelInfo,
 			openRouterUseMiddleOutTransform,
@@ -1208,6 +1212,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getSecret("openAiNativeApiKey") as Promise<string | undefined>,
 			this.getSecret("deepSeekApiKey") as Promise<string | undefined>,
 			this.getGlobalState("azureApiVersion") as Promise<string | undefined>,
+			this.getGlobalState("includeStreamOptions") as Promise<boolean | undefined>,
 			this.getGlobalState("openRouterModelId") as Promise<string | undefined>,
 			this.getGlobalState("openRouterModelInfo") as Promise<ModelInfo | undefined>,
 			this.getGlobalState("openRouterUseMiddleOutTransform") as Promise<boolean | undefined>,
@@ -1270,6 +1275,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				openAiNativeApiKey,
 				deepSeekApiKey,
 				azureApiVersion,
+				includeStreamOptions,
 				openRouterModelId,
 				openRouterModelInfo,
 				openRouterUseMiddleOutTransform,


### PR DESCRIPTION
Got a bug report that this checkbox wasn't serializing correctly
<img width="416" alt="Screenshot 2024-12-31 at 10 02 31 PM" src="https://github.com/user-attachments/assets/cb06925f-fdf3-4cf0-8faf-25c11329d250" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix serialization of 'allow stream options' checkbox by adding `includeStreamOptions` to global state management in `ClineProvider.ts`.
> 
>   - **Behavior**:
>     - Fix serialization of 'allow stream options' checkbox by adding `includeStreamOptions` to `GlobalStateKey` in `ClineProvider.ts`.
>     - Update `updateGlobalState` and `getGlobalState` calls to handle `includeStreamOptions` in `ClineProvider` class.
>   - **Code Changes**:
>     - Add `includeStreamOptions` to the list of global state keys in `ClineProvider.ts`.
>     - Update `ClineProvider` constructor and methods to include `includeStreamOptions` in state management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 92c230341679bd3f62969af0f631f6b225dbc9d4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->