### PR TITLE
Add toggle to enable or disable MCP servers on the system prompt

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -788,8 +788,10 @@ export class Cline {
 			throw new Error("MCP hub not available")
 		}
 
+    const mcpEnabled = this.providerRef.deref()?.mcpEnabled ?? true;
+
 		const { browserViewportSize, preferredLanguage } = await this.providerRef.deref()?.getState() ?? {}
-		const systemPrompt = await SYSTEM_PROMPT(cwd, this.api.getModel().info.supportsComputerUse ?? false, mcpHub, this.diffStrategy, browserViewportSize) + await addCustomInstructions(this.customInstructions ?? '', cwd, preferredLanguage)
+		const systemPrompt = await SYSTEM_PROMPT(cwd, this.api.getModel().info.supportsComputerUse ?? false, mcpEnabled, mcpHub, this.diffStrategy, browserViewportSize) + await addCustomInstructions(this.customInstructions ?? '', cwd, preferredLanguage)
 
 		// If the previous API request's total token usage is close to the context window, truncate the conversation history to free up space for the new request
 		if (previousApiReqIndex >= 0) {

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -9,6 +9,7 @@ import { McpHub } from "../../services/mcp/McpHub"
 export const SYSTEM_PROMPT = async (
 	cwd: string,
 	supportsComputerUse: boolean,
+	mcpEnabled: boolean,
 	mcpHub: McpHub,
 	diffStrategy?: DiffStrategy,
 	browserViewportSize?: string
@@ -146,6 +147,7 @@ Usage:
 		: ""
 }
 
+${mcpEnabled ? `
 ## use_mcp_tool
 Description: Request to use a tool provided by a connected MCP server. Each MCP server can provide multiple tools with different capabilities. Tools have defined input schemas that specify required and optional parameters.
 Parameters:
@@ -173,7 +175,7 @@ Usage:
 <access_mcp_resource>
 <server_name>server name here</server_name>
 <uri>resource URI here</uri>
-</access_mcp_resource>
+</access_mcp_resource>` : ''}
 
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
@@ -229,6 +231,7 @@ Your final result description here
 <line_count>14</line_count>
 </write_to_file>
 
+${mcpEnabled ? `
 ## Example 3: Requesting to use an MCP tool
 
 <use_mcp_tool>
@@ -247,7 +250,7 @@ Your final result description here
 <access_mcp_resource>
 <server_name>weather-server</server_name>
 <uri>weather://san-francisco/current</uri>
-</access_mcp_resource>
+</access_mcp_resource>` : ''}
 
 # Tool Use Guidelines
 
@@ -272,6 +275,7 @@ By waiting for and carefully considering the user's response after each tool use
 
 ====
 
+${mcpEnabled ? `
 MCP SERVERS
 
 The Model Context Protocol (MCP) enables communication between the system and locally running MCP servers that provide additional tools and resources to extend your capabilities.
@@ -675,7 +679,7 @@ However some MCP servers may be running from installed packages rather than a lo
 
 The user may not always request the use or creation of MCP servers. Instead, they might provide tasks that can be completed with existing tools. While using the MCP SDK to extend your capabilities can be useful, it's important to understand that this is just one specialized type of task you can accomplish. You should only implement MCP servers when the user explicitly requests it (e.g., "add a tool that...").
 
-Remember: The MCP documentation and example provided above are to help you understand and work with existing MCP servers or create new ones when requested by the user. You already have access to tools and capabilities that can be used to accomplish a wide range of tasks.
+Remember: The MCP documentation and example provided above are to help you understand and work with existing MCP servers or create new ones when requested by the user. You already have access to tools and capabilities that can be used to accomplish a wide range of tasks.` : ''}
 
 ====
  
@@ -693,7 +697,9 @@ CAPABILITIES
 		? "\n- You can use the browser_action tool to interact with websites (including html files and locally running development servers) through a Puppeteer-controlled browser when you feel it is necessary in accomplishing the user's task. This tool is particularly useful for web development tasks as it allows you to launch a browser, navigate to pages, interact with elements through clicks and keyboard input, and capture the results through screenshots and console logs. This tool may be useful at key stages of web development tasks-such as after implementing new features, making substantial changes, when troubleshooting issues, or to verify the result of your work. You can analyze the provided screenshots to ensure correct rendering or identify errors, and review console logs for runtime issues.\n	- For example, if asked to add a component to a react website, you might create the necessary files, use execute_command to run the site locally, then use browser_action to launch the browser, navigate to the local server, and verify the component renders & functions correctly before closing the browser."
 		: ""
 }
+${mcpEnabled ? `
 - You have access to MCP servers that may provide additional tools and resources. Each server may provide different capabilities that you can use to accomplish tasks more effectively.
+` : ''}
 
 ====
 

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -255,6 +255,7 @@ describe('ClineProvider', () => {
             writeDelayMs: 1000,
             browserViewportSize: "900x600",
             fuzzyMatchThreshold: 1.0,
+            mcpEnabled: true,
         }
         
         const message: ExtensionMessage = { 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -62,6 +62,7 @@ export interface ExtensionState {
 	preferredLanguage: string
 	writeDelayMs: number
 	terminalOutputLineLimit?: number
+	mcpEnabled: boolean
 }
 
 export interface ClineMessage {

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -49,6 +49,7 @@ export interface WebviewMessage {
 		| "draggedImages"
 		| "deleteMessage"
 		| "terminalOutputLineLimit"
+		| "mcpEnabled"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -48,6 +48,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		setScreenshotQuality,
 		terminalOutputLineLimit,
 		setTerminalOutputLineLimit,
+		mcpEnabled,
+		setMcpEnabled,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
@@ -79,6 +81,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			vscode.postMessage({ type: "writeDelayMs", value: writeDelayMs })
 			vscode.postMessage({ type: "screenshotQuality", value: screenshotQuality ?? 75 })
 			vscode.postMessage({ type: "terminalOutputLineLimit", value: terminalOutputLineLimit ?? 500 })
+			vscode.postMessage({ type: "mcpEnabled", bool: mcpEnabled })
 			onDone()
 		}
 	}
@@ -211,6 +214,21 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 						}}>
 						These instructions are added to the end of the system prompt sent with every request. Custom instructions set in .clinerules and .cursorrules in the working directory are also included.
 					</p>
+
+          <div style={{ marginBottom: 5 }}>
+            <VSCodeCheckbox
+              checked={mcpEnabled}
+              onChange={(e: any) => setMcpEnabled(e.target.checked)}>
+              <span style={{ fontWeight: "500" }}>Enable MCP Servers</span>
+            </VSCodeCheckbox>
+            <p style={{
+              fontSize: "12px",
+              marginTop: "5px",
+              color: "var(--vscode-descriptionForeground)",
+            }}>
+              When enabled, Cline will be able to interact with MCP servers for advanced functionality.
+            </p>
+          </div>
 				</div>
 
 				<div style={{ marginBottom: 5 }}>
@@ -557,6 +575,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 						)}
 					</div>
 				</div>
+
 
 				{IS_DEV && (
 					<>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -41,6 +41,8 @@ export interface ExtensionStateContextType extends ExtensionState {
 	setScreenshotQuality: (value: number) => void
 	terminalOutputLineLimit?: number
 	setTerminalOutputLineLimit: (value: number) => void
+	mcpEnabled: boolean
+	setMcpEnabled: (value: boolean) => void
 }
 
 export const ExtensionStateContext = createContext<ExtensionStateContextType | undefined>(undefined)
@@ -61,6 +63,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		browserViewportSize: "900x600",
 		screenshotQuality: 75,
 		terminalOutputLineLimit: 500,
+		mcpEnabled: true,
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)
@@ -180,6 +183,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setWriteDelayMs: (value) => setState((prevState) => ({ ...prevState, writeDelayMs: value })),
 		setScreenshotQuality: (value) => setState((prevState) => ({ ...prevState, screenshotQuality: value })),
 		setTerminalOutputLineLimit: (value) => setState((prevState) => ({ ...prevState, terminalOutputLineLimit: value })),
+		setMcpEnabled: (value) => setState((prevState) => ({ ...prevState, mcpEnabled: value })),
 	}
 
 	return <ExtensionStateContext.Provider value={contextValue}>{children}</ExtensionStateContext.Provider>


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->
## Description

Added a checkbox that allows the user to disable MCP mentions in the system prompt, the user might not be interested in MCP servers and disabling them can save between 3k to 4k input tokens.

![image](https://github.com/user-attachments/assets/79100203-09e0-4fb7-8d4f-5dadc54c6a11)

With MCPs in the system prompt enabled:
![image (1)](https://github.com/user-attachments/assets/1308c9a2-6db0-4ea6-9192-2407c4396276)

With MCPs in the system prompt disabled:
![image](https://github.com/user-attachments/assets/099f0171-aeb6-4922-bcd0-1d3f00d5eb4a)


## Type of change
<!-- Please ignore options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes -->
I used the extension after implementing my changes, disabling MCP servers simply removes the parts of the system prompt with information about them.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context
<!-- Add any other context or screenshots about the pull request here -->

## Related Issues
<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers
<!-- @mention specific team members or individuals who should review this PR -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a toggle in settings to enable or disable MCP servers in the system prompt, updating state management and tests accordingly.
> 
>   - **Behavior**:
>     - Adds a checkbox in `SettingsView.tsx` to enable/disable MCP servers, affecting the system prompt.
>     - Updates `Cline.ts` to conditionally include MCP server information in the system prompt based on the new setting.
>   - **State Management**:
>     - Adds `mcpEnabled` to `ExtensionState` in `ExtensionMessage.ts` and `WebviewMessage.ts`.
>     - Updates `ClineProvider.ts` to handle `mcpEnabled` state, including saving/loading from global state.
>   - **Testing**:
>     - Adds test for `mcpEnabled` state in `ClineProvider.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for c8200de53cf39454e4eac8311410c953eefa9a1b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->