### PR TITLE
Remove API proposals

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
     "url": "https://github.com/RooVetGit/Roo-Cline"
   },
   "homepage": "https://github.com/RooVetGit/Roo-Cline",
-  "enabledApiProposals": [
-    "extensionRuntime"
-  ],
   "categories": [
     "AI",
     "Chat",


### PR DESCRIPTION
This is preventing us from publishing the extension. Running `npm run test:extension` seems to work without it.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `enabledApiProposals` from `package.json` to enable extension publishing.
> 
>   - **Behavior**:
>     - Removes `enabledApiProposals` field from `package.json`, which included `extensionRuntime`.
>     - Allows publishing the extension without affecting test execution (`npm run test:extension`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 80387a4d27f56dbb1d06a6a68e727c13d810551c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->