### PR TITLE
Use jest-simple-dot-reporter to cut down on test noise

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -32,6 +32,9 @@ module.exports = {
     modulePathIgnorePatterns: [
         '.vscode-test'
     ],
+    reporters: [
+        ["jest-simple-dot-reporter", {}]
+    ],
     setupFiles: [],
     globals: {
         'ts-jest': {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "eslint": "^8.57.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
+        "jest-simple-dot-reporter": "^1.0.5",
         "lint-staged": "^15.2.11",
         "npm-run-all": "^4.1.5",
         "ts-jest": "^29.2.5",
@@ -10892,6 +10893,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/jest-simple-dot-reporter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/jest-simple-dot-reporter/-/jest-simple-dot-reporter-1.0.5.tgz",
+      "integrity": "sha512-cZLFG/C7k0+WYoIGGuGXKm0vmJiXlWG/m3uCZ4RaMPYxt8lxjdXMLHYkxXaQ7gVWaSPe7uAPCEUcRxthC5xskg==",
+      "dev": true
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "eslint": "^8.57.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
+    "jest-simple-dot-reporter": "^1.0.5",
     "lint-staged": "^15.2.11",
     "npm-run-all": "^4.1.5",
     "ts-jest": "^29.2.5",


### PR DESCRIPTION
This generates much less output when running the tests in this repo
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `jest-simple-dot-reporter` to reduce Jest test output noise.
> 
>   - **Testing**:
>     - Added `jest-simple-dot-reporter` to `jest.config.js` to reduce test output noise.
>     - Updated `package.json` to include `jest-simple-dot-reporter` as a dev dependency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 305b1342ede53d2f3e227709e3489e94ee13c329. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->