### PR TITLE
Only load context and parse @-mentions in user input

### DIFF
--- a/.changeset/odd-news-yell.md
+++ b/.changeset/odd-news-yell.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Only parse @-mentions in user input (not in files)


### PR DESCRIPTION
This is an attempt to fix the issue in https://github.com/cline/cline/issues/628 where Cline is expanding mentions in files that it reads (particularly when the file contains `@/...`).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `Cline.ts` to parse @-mentions only in user input within `<task>` and `<feedback>` tags, with tests in `Cline.test.ts`.
> 
>   - **Behavior**:
>     - Modify `Cline.ts` to only parse @-mentions in user input within `<task>` and `<feedback>` tags.
>     - Regular text and tool results without these tags are not processed for mentions.
>   - **Tests**:
>     - Add test in `Cline.test.ts` to verify that mentions are processed in `<task>` and `<feedback>` tags.
>     - Ensure regular text and tool results without these tags are not processed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 48edfe668950d06d51562980af20c14c448640ca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->