### PR TITLE
adding ability to publish to OVSX as part of publish workflow

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Package and Publish Extension
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
           current_package_version=$(node -p "require('./package.json').version")
           npm run publish:marketplace
           echo "Successfully published version $current_package_version to VS Code Marketplace"
+

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "test:webview": "cd webview-ui && npm run test",
     "test:extension": "vscode-test",
     "prepare": "husky",
-    "publish:marketplace": "vsce publish",
+    "publish:marketplace": "vsce publish && ovsx publish",
     "publish": "npm run build && changeset publish && npm install --package-lock-only",
     "version-packages": "changeset version && npm install --package-lock-only",
     "vscode:prepublish": "npm run package",


### PR DESCRIPTION
### Description

Add functionality to publish extension to OVSX marketplace as part of publish GHA

### Type of Change

<!-- Put an 'x' in all boxes that apply -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] 📚 Documentation update

### Pre-flight Checklist

<!-- Put an 'x' in all boxes that apply -->

-   [x] Changes are limited to a single feature, bugfix or chore (split larger changes into separate PRs)
-   [x] Tests are passing (`npm test`) and code is formatted and linted (`npm run format && npm run lint`)
-   [x] I have reviewed [contributor guidelines](https://github.com/cline/cline/blob/main/CONTRIBUTING.md)

### Screenshots

n/a

### Additional Notes

n/a

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add functionality to publish extensions to OVSX marketplace in the GitHub Actions workflow and `package.json`.
> 
>   - **Workflow Changes**:
>     - Update `.github/workflows/marketplace-publish.yml` to include `OVSX_PAT` for publishing to OVSX.
>     - Modify `Package and Publish Extension` step to use `ovsx publish`.
>   - **Scripts**:
>     - Update `publish:marketplace` script in `package.json` to run `vsce publish && ovsx publish`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 1a165522aaa90ed89c5a77d839deb290a4c2a313. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->