### PR TITLE
Update openai package and use developer role message for o1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "isbinaryfile": "^5.0.2",
         "mammoth": "^1.8.0",
         "monaco-vscode-textmate-theme-converter": "^0.1.7",
-        "openai": "^4.73.1",
+        "openai": "^4.78.1",
         "os-name": "^6.0.0",
         "p-wait-for": "^5.0.2",
         "pdf-parse": "^1.1.1",
@@ -12546,9 +12546,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.76.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.76.0.tgz",
-      "integrity": "sha512-QBGIetjX1C9xDp5XGa/3mPnfKI9BgAe2xHQX6PmO98wuW9qQaurBaumcYptQWc9LHZZq7cH/Y1Rjnsr6uUDdVw==",
+      "version": "4.78.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.78.1.tgz",
+      "integrity": "sha512-drt0lHZBd2lMyORckOXFPQTmnGLWSLt8VK0W9BhOKWpMFBEoHMoz5gxMPmVq5icp+sOrsbMnsmZTVHUlKvD1Ow==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -227,7 +227,7 @@
     "isbinaryfile": "^5.0.2",
     "mammoth": "^1.8.0",
     "monaco-vscode-textmate-theme-converter": "^0.1.7",
-    "openai": "^4.73.1",
+    "openai": "^4.78.1",
     "os-name": "^6.0.0",
     "p-wait-for": "^5.0.2",
     "pdf-parse": "^1.1.1",

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -23,14 +23,16 @@ export class OpenAiNativeHandler implements ApiHandler, SingleCompletionHandler 
 	}
 
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
-		switch (this.getModel().id) {
+		const modelId = this.getModel().id
+		switch (modelId) {
 			case "o1":
 			case "o1-preview":
 			case "o1-mini": {
-				// o1 doesnt support streaming, non-1 temp, or system prompt
+				// o1-preview and o1-mini don't support streaming, non-1 temp, or system prompt
+				// o1 doesnt support streaming or non-1 temp but does support a developer prompt
 				const response = await this.client.chat.completions.create({
-					model: this.getModel().id,
-					messages: [{ role: "user", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
+					model: modelId,
+					messages: [{ role: modelId === "o1" ? "developer" : "user", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 				})
 				yield {
 					type: "text",
@@ -93,7 +95,7 @@ export class OpenAiNativeHandler implements ApiHandler, SingleCompletionHandler 
 				case "o1":
 				case "o1-preview":
 				case "o1-mini":
-					// o1 doesn't support non-1 temp or system prompt
+					// o1 doesn't support non-1 temp
 					requestOptions = {
 						model: modelId,
 						messages: [{ role: "user", content: prompt }]


### PR DESCRIPTION
From https://platform.openai.com/docs/guides/reasoning#limitations:
>Developer messages are the new system messages: Starting with o1-2024-12-17, o1 models support developer messages rather than system messages, to align with the [chain of command behavior described in the model spec](https://cdn.openai.com/spec/model-spec-2024-05-08.html#follow-the-chain-of-command). [Learn more](https://platform.openai.com/docs/guides/text-generation#building-prompts).
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update OpenAI package and modify `o1` model handling to use developer role messages in `openai-native.ts` and tests.
> 
>   - **Behavior**:
>     - Update `openai` package version to `^4.78.1` in `package.json`.
>     - Modify `createMessage` in `openai-native.ts` to use `developer` role for `o1` model system prompts.
>     - Add handling for missing content in `createMessage` for `o1` model in `openai-native.test.ts`.
>   - **Tests**:
>     - Add test for `o1` model handling missing content in `openai-native.test.ts`.
>     - Verify `developer` role usage for `o1` model in `openai-native.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 6e90bcf4a35c5d059d95b0f938b0bfa68ff63196. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->