### PR TITLE
A couple more tiny tweaks to buttons

### DIFF
--- a/.changeset/thirty-doors-perform.md
+++ b/.changeset/thirty-doors-perform.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+A couple more tiny tweaks to the button alignment in the chat input

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -666,7 +666,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						style={{
 							position: "absolute",
 							paddingTop: 4,
-							bottom: 32,
+							bottom: 36,
 							left: 22,
 							right: 67,
 							zIndex: 2,
@@ -677,7 +677,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					style={{
 						position: "absolute",
 						left: 25,
-						bottom: 19,
+						bottom: 20,
 						zIndex: 3,
 						display: "flex",
 						gap: 8,
@@ -764,7 +764,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						))}
 					</select>
 				</div>
-				<div className="button-row" style={{ position: "absolute", right: 20, display: "flex", alignItems: "center", height: 31, bottom: 10, zIndex: 3, padding: "0 0 0 8px", justifyContent: "flex-end", backgroundColor: "var(--vscode-input-background)", }}>
+				<div className="button-row" style={{ position: "absolute", right: 16, display: "flex", alignItems: "center", height: 31, bottom: 11, zIndex: 3, padding: "0 8px", justifyContent: "flex-end", backgroundColor: "var(--vscode-input-background)", }}>
 				  <span style={{ display: "flex", alignItems: "center", gap: 12 }}>
 					{apiConfiguration?.apiProvider === "openrouter" && (
 					  <div style={{ display: "flex", alignItems: "center" }}>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Minor UI adjustments to button alignment in `ChatTextArea.tsx`.
> 
>   - **UI Adjustments**:
>     - Adjusted `bottom` from 32 to 36 for the `Thumbnails` div in `ChatTextArea.tsx`.
>     - Adjusted `bottom` from 19 to 20 for a button container in `ChatTextArea.tsx`.
>     - Adjusted `right` from 20 to 16 and `bottom` from 10 to 11 for the `button-row` div in `ChatTextArea.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for b53d63abdae46eeee5de886405b3bdb746af558f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->