### PR TITLE
Update required vscode engine to ^1.84.0 to match cline

### DIFF
--- a/.changeset/early-mails-knock.md
+++ b/.changeset/early-mails-knock.md
@@ -2,4 +2,4 @@
 "roo-cline": patch
 ---
 
-Update required vscode engine to ^1.84.0 to match cline"
+Update required vscode engine to ^1.84.0 to match cline

--- a/.changeset/early-mails-knock.md
+++ b/.changeset/early-mails-knock.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Update required vscode engine to ^1.84.0 to match cline"

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "typescript": "^5.4.5"
       },
       "engines": {
-        "vscode": "^1.93.1"
+        "vscode": "^1.84.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "theme": "dark"
   },
   "engines": {
-    "vscode": "^1.93.1"
+    "vscode": "^1.84.0"
   },
   "author": {
     "name": "Roo Vet"


### PR DESCRIPTION
I don't think there's a reason that our requirement is higher than cline - does anyone remember? https://x.com/posi_posi8/status/1878699038746591274
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `vscode` engine requirement in `package.json` to `^1.84.0` to match cline.
> 
>   - **Engines**:
>     - Update `vscode` engine requirement in `package.json` from `^1.93.1` to `^1.84.0` to match cline.
>   - **Changeset**:
>     - Add `early-mails-knock.md` to document the engine version update as a patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for f1d01743fcd84d435842955a9b2d6dd3efa806ac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->