### PR TITLE
Add a button to copy markdown out of the chat

### DIFF
--- a/.changeset/real-rockets-sort.md
+++ b/.changeset/real-rockets-sort.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add a button to copy markdown out of the chat

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Give it a try and let us know what you think in the reddit: https://www.reddit.c
 - Sound effects for feedback
 - Option to use browsers of different sizes and adjust screenshot quality
 - Quick prompt copying from history
+- Copy markdown from chat messages
 - OpenRouter compression support
 - Includes current time in the system prompt
 - Uses a file system watcher to more reliably watch for file system changes


### PR DESCRIPTION
This shows a button on hover to copy the markdown out of chats - suggested by a [reddit comment](https://www.reddit.com/r/roocline/comments/1hzh80a/comment/m6wom7a/) and something I've been longing for since then, especially in architect mode.

![Screenshot 2025-01-14 at 1 34 40 AM](https://github.com/user-attachments/assets/d09f622b-379a-40a3-a20a-96a495131c63)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add a button to copy markdown from chat messages in `ChatRow.tsx`, with documentation updates in `README.md`.
> 
>   - **Feature**:
>     - Add a button to copy markdown from chat messages in `ChatRow.tsx`.
>     - Button appears on hover and copies markdown to clipboard.
>   - **Documentation**:
>     - Update `README.md` to include the new feature in the list of experimental features.
>   - **Misc**:
>     - Add changeset file `real-rockets-sort.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 5140b67d745044726f75d8f62303755dc54f5cb2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->