### PR TITLE
Fix bug with clearing custom instructions

### DIFF
--- a/.changeset/kind-nails-jog.md
+++ b/.changeset/kind-nails-jog.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix bug with clearing custom instructions

--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -21,7 +21,8 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 		enhancementApiConfigId,
 		setEnhancementApiConfigId,
 		mode,
-		customInstructions
+		customInstructions,
+		setCustomInstructions
 	} = useExtensionState()
 	const [testPrompt, setTestPrompt] = useState('')
 	const [isEnhancing, setIsEnhancing] = useState(false)
@@ -152,6 +153,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 						value={customInstructions ?? ''}
 						onChange={(e) => {
 							const value = (e as CustomEvent)?.detail?.target?.value || ((e as any).target as HTMLTextAreaElement).value
+							setCustomInstructions(value || undefined)
 							vscode.postMessage({
 								type: "customInstructions",
 								text: value.trim() || undefined

--- a/webview-ui/src/components/prompts/__tests__/PromptsView.test.tsx
+++ b/webview-ui/src/components/prompts/__tests__/PromptsView.test.tsx
@@ -19,7 +19,9 @@ const mockExtensionState = {
   ],
   enhancementApiConfigId: '',
   setEnhancementApiConfigId: jest.fn(),
-  mode: 'code'
+  mode: 'code',
+  customInstructions: 'Initial instructions',
+  setCustomInstructions: jest.fn()
 }
 
 const renderPromptsView = (props = {}) => {
@@ -129,6 +131,30 @@ describe('PromptsView', () => {
     expect(vscode.postMessage).toHaveBeenCalledWith({
       type: 'enhancementApiConfigId',
       text: 'config1'
+    })
+  })
+
+  it('handles clearing custom instructions correctly', async () => {
+    const setCustomInstructions = jest.fn()
+    renderPromptsView({
+      ...mockExtensionState,
+      customInstructions: 'Initial instructions',
+      setCustomInstructions
+    })
+
+    const textarea = screen.getByTestId('global-custom-instructions-textarea')
+    const changeEvent = new CustomEvent('change', {
+      detail: { target: { value: '' } }
+    })
+    Object.defineProperty(changeEvent, 'target', {
+      value: { value: '' }
+    })
+    await fireEvent(textarea, changeEvent)
+
+    expect(setCustomInstructions).toHaveBeenCalledWith(undefined)
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      type: 'customInstructions',
+      text: undefined
     })
   })
 })


### PR DESCRIPTION
There was a bug where you couldn't clear the custom instructions
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bug in `PromptsView.tsx` to correctly handle clearing of `customInstructions` and updates tests to validate this behavior.
> 
>   - **Behavior**:
>     - Fixes bug in `PromptsView.tsx` where clearing `customInstructions` did not update state correctly.
>     - Updates `onChange` handler to call `setCustomInstructions` with `undefined` when input is cleared.
>   - **Tests**:
>     - Adds test in `PromptsView.test.tsx` to verify clearing `customInstructions` sets state to `undefined` and sends correct message via `vscode.postMessage`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for f2d25dd5a5a4106d85169401a219fe090896278c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->