### PR TITLE
More fixes to checkbox state

### DIFF
--- a/.changeset/dull-gifts-rhyme.md
+++ b/.changeset/dull-gifts-rhyme.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Another fix to the auto approve menu

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -877,7 +877,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						await this.postStateToWebview()
 						break
 					case "autoApprovalEnabled":
-						await this.updateGlobalState("autoApprovalEnabled", message.bool)
+						await this.updateGlobalState("autoApprovalEnabled", message.bool ?? false)
 						await this.postStateToWebview()
 						break
 					case "enhancePrompt":
@@ -1644,6 +1644,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			mode,
 			customPrompts,
 			enhancementApiConfigId,
+			autoApprovalEnabled,
 		} = await this.getState()
 
 		const allowedCommands = vscode.workspace
@@ -1683,6 +1684,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			mode: mode ?? codeMode,
 			customPrompts: customPrompts ?? {},
 			enhancementApiConfigId,
+			autoApprovalEnabled: autoApprovalEnabled ?? false,
 		}
 	}
 
@@ -1797,6 +1799,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			modeApiConfigs,
 			customPrompts,
 			enhancementApiConfigId,
+			autoApprovalEnabled,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
 			this.getGlobalState("apiModelId") as Promise<string | undefined>,
@@ -1856,6 +1859,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("modeApiConfigs") as Promise<Record<Mode, string> | undefined>,
 			this.getGlobalState("customPrompts") as Promise<CustomPrompts | undefined>,
 			this.getGlobalState("enhancementApiConfigId") as Promise<string | undefined>,
+			this.getGlobalState("autoApprovalEnabled") as Promise<boolean | undefined>,
 		])
 
 		let apiProvider: ApiProvider
@@ -1959,6 +1963,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			modeApiConfigs: modeApiConfigs ?? {} as Record<Mode, string>,
 			customPrompts: customPrompts ?? {},
 			enhancementApiConfigId,
+			autoApprovalEnabled: autoApprovalEnabled ?? false,
 		}
 	}
 

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -93,6 +93,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		mode: codeMode,
 		customPrompts: defaultPrompts,
 		enhancementApiConfigId: '',
+		autoApprovalEnabled: false,
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)


### PR DESCRIPTION
Fixes to state persistence
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes to ensure `autoApprovalEnabled` defaults to `false` and is correctly managed in state across `ClineProvider.ts` and `ExtensionStateContext.tsx`.
> 
>   - **Behavior**:
>     - Default `autoApprovalEnabled` to `false` in `ClineProvider.ts` when not specified.
>     - Ensure `autoApprovalEnabled` is included in state updates in `ClineProvider.ts`.
>   - **State Management**:
>     - Initialize `autoApprovalEnabled` to `false` in `ExtensionStateContext.tsx`.
>     - Add `setAutoApprovalEnabled` function in `ExtensionStateContext.tsx` to update state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for 6254e742162b892f016cfa4fe67e7a4d9b4eb6c6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->