### PR TITLE
add: deepseek-reasoner model support

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -542,6 +542,15 @@ export const deepSeekModels = {
 		outputPrice: 0.28, // $0.28 per million tokens
 		description: `DeepSeek-V3 achieves a significant breakthrough in inference speed over previous models. It tops the leaderboard among open-source models and rivals the most advanced closed-source models globally.`,
 	},
+	"deepseek-reasoner": {
+		maxTokens: 8192,
+		contextWindow: 64_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.55, // $0.55 per million tokens
+		outputPrice: 2.19, // $2.19 per million tokens
+		description: `DeepSeek-R1 achieves performance comparable to OpenAI-o1 across math, code, and reasoning tasks.`,
+	},
 } as const satisfies Record<string, ModelInfo>
 
 // Azure OpenAI


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

I add new model support for deepseek.

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `deepseek-reasoner` model to `deepSeekModels` in `api.ts` with specific attributes and description.
> 
>   - **Models**:
>     - Add `deepseek-reasoner` to `deepSeekModels` in `api.ts` with attributes: `maxTokens: 8192`, `contextWindow: 64_000`, `supportsImages: false`, `supportsPromptCache: false`, `inputPrice: 0.55`, `outputPrice: 2.19`, and a description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for cab095aef2d11a01fccfdf206a0a755597c1f07d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->